### PR TITLE
Requires user to be logged in order to access media folder items.

### DIFF
--- a/NEMO/urls.py
+++ b/NEMO/urls.py
@@ -289,7 +289,7 @@ urlpatterns += [
 	url(r'^news/publish/(?P<story_id>\d+)/$', news.publish, name='publish_news_update'),
 
 	# Media
-	url(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}, name='media'),
+	url(r'^media/(?P<path>.*)$', login_required(serve), {'document_root': settings.MEDIA_ROOT}, name='media'),
 
 	# User Preferences
 	url(r'^user_preferences/$', users.user_preferences, name='user_preferences'),


### PR DESCRIPTION
Hello and thanks for the great work!
Here goes an humble suggestion: from a security-wise perspective, it would be desirable to ensure files from the media folder are served only if a user is logged in.
In particular, it can be relevant in case were internal protocol/guidelines/policies need to be shared with the users but should not be publicly available.

This PR will prevents disclosure in case of predictable names or in case a link is shared to unauthorized users.

This minor change should not affect the normal functioning of NEMO, unless items from the media folder are used in the landing login page template.
If that is the case, the PR can be easily modified in order to limit the login requirement to a specific folder.