### PR TITLE
Fixed delayed container removal.

### DIFF
--- a/start_NEMO_in_Docker.sh
+++ b/start_NEMO_in_Docker.sh
@@ -10,4 +10,4 @@ django-admin migrate
 django-admin collectstatic --no-input --clear
 
 # Run NEMO
-gunicorn --config=/etc/gunicorn_configuration.py NEMO.wsgi:application
+exec gunicorn --config=/etc/gunicorn_configuration.py NEMO.wsgi:application


### PR DESCRIPTION
Added `exec` to the last command to avoid 10s delay on `docker compose down`.
This way  `SIGTERM` and `SIGKILL` signals are forwarded to the `gunicorn` process instead of the parent bash, which will otherwise time out.

While investigating the timeout, I found a nice explanation [here](https://vsupalov.com/docker-compose-stop-slow/).
