### PR TITLE
Avoid loading 'billing' in usage when not enabled

### DIFF
--- a/NEMO/views/usage.py
+++ b/NEMO/views/usage.py
@@ -91,7 +91,7 @@ def date_parameters_dictionary(request):
 		'end_date': end_date,
 		'kind': kind,
 		'identifier': identifier,
-		'tab_url': get_url_for_other_tab(request),
+		'tab_url': get_url_for_other_tab(request) if  get_billing_service().get('available', False) else '',
 		'billing_service': get_billing_service().get('available', False),
 	}
 	return dictionary, start_date, end_date, kind, identifier


### PR DESCRIPTION
Added conditional check to avoid `NoReverseMatch` exception when Billing functionality is not enabled. The 'usage' templates already had some sanity checks, but an extra one ws missing in `date_parameters_dictionary` function. Previous code resulted in exception and page not showing when running an instance with `'ALLOW_CONDITIONAL_URLS'=False`.