### PR TITLE
Added 'utf-8' encoding to email attachments.

### DIFF
--- a/NEMO/utilities.py
+++ b/NEMO/utilities.py
@@ -452,6 +452,7 @@ def create_email_log(email: EmailMessage, email_category: EmailCategory):
 def create_email_attachment(stream, filename=None, maintype="application", subtype="octet-stream", **content_type_params) -> MIMEBase:
 	attachment = MIMEBase(maintype, subtype, **content_type_params)
 	attachment.set_payload(stream.read())
+	attachment.set_charset('utf-8')
 	encoders.encode_base64(attachment)
 	if filename:
 		attachment.add_header("Content-Disposition", f'attachment; filename="{filename}"')

--- a/NEMO/utilities.py
+++ b/NEMO/utilities.py
@@ -452,7 +452,8 @@ def create_email_log(email: EmailMessage, email_category: EmailCategory):
 def create_email_attachment(stream, filename=None, maintype="application", subtype="octet-stream", **content_type_params) -> MIMEBase:
 	attachment = MIMEBase(maintype, subtype, **content_type_params)
 	attachment.set_payload(stream.read())
-	attachment.set_charset('utf-8')
+	if maintype == "text":
+		attachment.set_charset('utf-8')
 	encoders.encode_base64(attachment)
 	if filename:
 		attachment.add_header("Content-Disposition", f'attachment; filename="{filename}"')


### PR DESCRIPTION
Fixes #137.

Added 'utf-8' encoding before base64 conversion.
Might need to be limited only for attachments with `maintype == 'text'`.