### PR TITLE
Change `NEMO` to `{{ site_title }}` in email templates

### DIFF
--- a/resources/emails/access_request_notification_email.html
+++ b/resources/emails/access_request_notification_email.html
@@ -39,7 +39,7 @@
             </tr>
             <tr>
                 <td style="padding: 10px;">
-                    Visit the <a href="{{ access_requests_url }}">NEMO access requests page</a> for more information.<br/>
+                    Visit the <a href="{{ access_requests_url }}">{{ site_title }} access requests page</a> for more information.<br/>
                 </td>
             </tr>
         </table>

--- a/resources/emails/adjustment_request_notification_email.html
+++ b/resources/emails/adjustment_request_notification_email.html
@@ -40,7 +40,7 @@
             </tr>
             <tr>
                 <td style="padding: 10px;">
-                    Visit the <a href="{{ adjustment_request_url }}">NEMO adjustment requests page</a> for more information.<br/>
+                    Visit the <a href="{{ adjustment_request_url }}">{{ site_title }} adjustment requests page</a> for more information.<br/>
                 </td>
             </tr>
         </table>

--- a/resources/emails/cancellation_email.html
+++ b/resources/emails/cancellation_email.html
@@ -19,7 +19,7 @@
                     <p>{{ staff_member }} cancelled your reservation for the {{ reservation.reservation_item }} starting on {{ reservation.start }} and ending on {{ reservation.end }}.</p>
                     <p>{{ staff_member.first_name }} provided this reason for cancelling the reservation:</p>
                     <div style="border-left: 5px solid #5bc0de; padding-left: 7px; font-style: italic">{{ reason }}</div>
-                    <p>You can reply to this message to contact {{ staff_member.first_name }} if you believe the reservation should not have been cancelled, or log in to NEMO to schedule a new reservation.</p>
+                    <p>You can reply to this message to contact {{ staff_member.first_name }} if you believe the reservation should not have been cancelled, or log in to {{ site_title }} to schedule a new reservation.</p>
                 </td>
             </tr>
         </table>

--- a/resources/emails/missed_reservation_email.html
+++ b/resources/emails/missed_reservation_email.html
@@ -25,7 +25,7 @@
                         {% else %}The tool was not used for more than
                         {% endif %}
                         {{ reservation.reservation_item.missed_reservation_threshold }} minutes after the start
-                        of your reservation, therefore your reservation time has been marked as 'missed' in NEMO and cancelled on the calendar.
+                        of your reservation, therefore your reservation time has been marked as 'missed' in {{ site_title }} and cancelled on the calendar.
                     </p>
                     <p>
                         Please remember that the facility is a shared resource, and missing a reservation may inhibit the productivity of other facility users.

--- a/resources/emails/new_task_email.html
+++ b/resources/emails/new_task_email.html
@@ -22,7 +22,7 @@
                     {% endif %}
 
                     <p>
-                        You are receiving this message because {{ user }} reported a problem via NEMO. You can contact {{ user }} directly by replying to this email.
+                        You are receiving this message because {{ user }} reported a problem via {{ site_title }}. You can contact {{ user }} directly by replying to this email.
                     </p>
 
                     {% if task.force_shutdown %}

--- a/resources/emails/reorder_supplies_reminder_email.html
+++ b/resources/emails/reorder_supplies_reminder_email.html
@@ -20,7 +20,7 @@
                     </p>
                     <br>
                     <p>
-                        You can update the available quantity in the detailed administration of NEMO.
+                        You can update the available quantity in the detailed administration of {{ site_title }}.
                     </p>
                 </td>
             </tr>

--- a/resources/emails/reservation_reminder_email.html
+++ b/resources/emails/reservation_reminder_email.html
@@ -19,7 +19,7 @@
                     <p>
                         Your <b>{{ reservation.reservation.reservation_item }}</b> reservation begins at <b>{{ reservation.start|time }}</b>.
                         <br>
-                        Please log in to NEMO if you need to modify or cancel your reservation.
+                        Please log in to {{ site_title }} if you need to modify or cancel your reservation.
                     </p>
                 </td>
             </tr>

--- a/resources/emails/reservation_warning_email.html
+++ b/resources/emails/reservation_warning_email.html
@@ -19,10 +19,10 @@
                     <p>
                         {% if fatal_error %}
                             There is a problem with your <b>{{ reservation.start|time }}</b> reservation for the <b>{{ reservation.tool }}</b>.
-                            The tool was <b>shut down</b> when this email was sent. Please visit to NEMO to view current tool status.
+                            The tool was <b>shut down</b> when this email was sent. Please visit {{ site_title }} to view current tool status.
                         {% else %}
                             There may be a problem with your <b>{{ reservation.start|time }}</b> reservation for the <b>{{ reservation.tool }}</b>.
-                            The tool may be operating in a diminished capacity or may not be able to perform certain processes. Please visit NEMO to view current tool status.
+                            The tool may be operating in a diminished capacity or may not be able to perform certain processes. Please visit {{ site_title }} to view current tool status.
                         {% endif %}
                     </p>
 

--- a/resources/emails/safety_issue_email.html
+++ b/resources/emails/safety_issue_email.html
@@ -24,7 +24,7 @@
                         </div>
                     </p>
                     <p>
-                        You can <a href="{{ issue_absolute_url }}">view and edit</a> this issue in NEMO.
+                        You can <a href="{{ issue_absolute_url }}">view and edit</a> this issue in {{ site_title }}.
                     </p>
                 </td>
             </tr>

--- a/resources/emails/staff_charge_reminder_email.html
+++ b/resources/emails/staff_charge_reminder_email.html
@@ -20,7 +20,7 @@
                         This is a friendly reminder that you have been charging staff time to <b>{{ staff_charge.customer }}</b> while working on
                         the project named <b>{{ staff_charge.project }}</b> since <b>{{ staff_charge.start }}</b>.
                         <br>
-                        You can	stop charging staff time by visiting the Staff Charges page in NEMO.
+                        You can	stop charging staff time by visiting the Staff Charges page in {{ site_title }}.
                         <br><br>
                         If you wish to adjust the amount of time charged then please contact the staff by replying to this email.
                     </p>

--- a/resources/emails/usage_reminder_email.html
+++ b/resources/emails/usage_reminder_email.html
@@ -22,7 +22,7 @@
                             <li>{{ resource }}</li>
                         {% endfor %}
                     </ul>
-                    <p>While on campus, you can relinquish tool control by visiting NEMO.</p>
+                    <p>While on campus, you can relinquish tool control by visiting {{ site_title }}.</p>
                     <p>
                         If you are off campus, the staff can assist you with relinquishing tool control (if you forgot to do so).
                         You can reply to this email to contact staff with any questions or concerns.


### PR DESCRIPTION
The PR edits changes the hard-coded `NEMO` value to `Site Title` variable across email templates.
It is mainly a suggestion, since it could be an easier reference which requires less customization when setting up a new installation.
