### PR TITLE
Web API Interlock

### DIFF
--- a/resources/fixtures/splash_pad.json
+++ b/resources/fixtures/splash_pad.json
@@ -623,6 +623,14 @@
     }
   },
   {
+    "model": "NEMO.interlockcardcategory",
+    "pk": 5,
+    "fields": {
+      "name": "WebAPI",
+      "key": "web_api"
+    }
+  },
+  {
     "model": "NEMO.taskcategory",
     "pk": 1,
     "fields": {


### PR DESCRIPTION
Hello,

This is another customization that we've been using at UC Irvine for calling an API to turn tools on and off. I've made it so hopefully the code is a little more generic and could be used by others who need to connect to an API for tool control.

Our use case is that we have a Java application that interacts with control boxes over the internet. We wanted to keep the control box logic outside of NEMO. We just need NEMO to interact with this API by calling an on or off endpoint with a tool ID specified.

Here's some more details of how it works.

### Interlock Card

* Set `Server` to the API's base URL (needs http/https; no trailing slash either)
* Set `Port` to the API's port
* Set `Username` and `Password` for authenticating

### Interlock

* Set `Channel/Relay/Coil` to an identifier for the tool, so the API knows which tool to turn on or off
 
### `settings.py` variables
* `WEB_API_OFF_ENDPOINT`: The endpoint to turn the tool off (example: `/my_api/v1/off`)
* `WEB_API_ON_ENDPOINT`: The endpoint to turn the tool on (example: `/my_api/v1/on`)
* `WEB_API_METHOD`: *Optional*: Set the HTTP method to use (either set to `put` (*default*) or `post`)
* `WEB_API_USERNAME`: *Optional*: Set the username in settings instead of in the admin interface
* `WEB_API_PASSWORD`: *Optional*: Set the password in settings instead of in the admin interface

### Testing
* Here's a simple Flask app to test the Web API Interlock: https://gist.github.com/abuckles-uci/f1084012b4c76fda5575d1625566454b
* Set `WEB_API_OFF_ENDPOINT = "/off"` and `WEB_API_ON_ENDPOINT = "/on"` in NEMO's `settings.py`
* Create an Interlock Card
  * Set `Server` to `http://localhost`
  * Set `Port` to `5000`
  * Set `Category` to `WebAPI`
  * Set `Username` to `test_user`
* Create an Interlock
  * Set `Card` to the card created above
  * Set `Channel/Relay/Coil` to any number
* Create a Tool with the Interlock created above
* View the API's logs when turning the tool on/off