### PR TITLE
Mark question_data field as not required

### DIFF
--- a/NEMO/serializers.py
+++ b/NEMO/serializers.py
@@ -196,7 +196,7 @@ class ConfigurationSerializer(FlexFieldsSerializerMixin, ModelSerializer):
 
 
 class ReservationSerializer(FlexFieldsSerializerMixin, ModelSerializer):
-    question_data = serializers.JSONField(source="question_data_json")
+    question_data = serializers.JSONField(source="question_data_json", allow_null=True, required=False)
     configuration_options = ConfigurationOptionSerializer(source="configurationoption_set", many=True, read_only=True)
 
     class Meta:


### PR DESCRIPTION
When pushing new reservation data through the API, the server complains that `question_data` must be present and cannot be null, even though the field in the DB for the Reservation table can indeed be null. This fix allows new reservations to be pushed through the API without requiring the `question_data` field to be present.