### PR TITLE
Remove links from tooltips in kiosks.

### DIFF
--- a/NEMO/apps/kiosk/templates/kiosk/kiosk.html
+++ b/NEMO/apps/kiosk/templates/kiosk/kiosk.html
@@ -40,6 +40,10 @@
 			margin-bottom: 50px;
 			font-size: 36px;
 		}
+        .tooltip .tooltip-inner a
+        {
+            pointer-events: none;
+        }
 	</style>
 </head>
 <body>


### PR DESCRIPTION
Fixed #202.

Prevents users from exiting the kiosk page.