### PR TITLE
Enable training for non-visible tools.

### DIFF
--- a/NEMO/templates/customizations/customizations_training.html
+++ b/NEMO/templates/customizations/customizations_training.html
@@ -36,6 +36,21 @@
                 <div class="help-block light-grey" style="margin-bottom: 0">Qualifications will still happen in real time</div>
             </div>
         </div>
+        <div class="form-group">
+            <label class="control-label col-lg-3 col-md-4 col-sm-5">Hidden Tools</label>
+            <div class="col-lg-9 col-md-8 col-sm-7">
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox"
+                               id="training_allow_hidden"
+                               name="training_allow_hidden"
+                               {% if training_allow_hidden %}checked{% endif %}
+                               value="enabled">
+                        Allow trainer to register trainings for hidden tools.
+                    </label>
+                </div>
+            </div>
+        </div>
         <div class="customization-separation" style="margin-bottom: 15px"></div>
         <div class="text-center">{% button type="save" value="Save settings" %}</div>
     </form>

--- a/NEMO/templates/customizations/customizations_training.html
+++ b/NEMO/templates/customizations/customizations_training.html
@@ -42,11 +42,11 @@
                 <div class="checkbox">
                     <label>
                         <input type="checkbox"
-                               id="training_allow_hidden"
-                               name="training_allow_hidden"
-                               {% if training_allow_hidden %}checked{% endif %}
+                               id="training_allow_hidden_tools"
+                               name="training_allow_hidden_tools"
+                               {% if training_allow_hidden_tools %}checked{% endif %}
                                value="enabled">
-                        Allow trainer to register trainings for hidden tools.
+                        Allow trainer to record trainings for hidden tools.
                     </label>
                 </div>
             </div>

--- a/NEMO/views/customization.py
+++ b/NEMO/views/customization.py
@@ -543,7 +543,7 @@ class RemoteWorkCustomization(CustomizationBase):
 
 @customization(key="training", title="Training")
 class TrainingCustomization(CustomizationBase):
-    variables = {"training_only_type": "", "training_allow_date": "", "training_allow_hidden": ""}
+    variables = {"training_only_type": "", "training_allow_date": "", "training_allow_hidden_tools": ""}
 
     def context(self) -> Dict:
         dictionary = super().context()

--- a/NEMO/views/customization.py
+++ b/NEMO/views/customization.py
@@ -543,7 +543,7 @@ class RemoteWorkCustomization(CustomizationBase):
 
 @customization(key="training", title="Training")
 class TrainingCustomization(CustomizationBase):
-    variables = {"training_only_type": "", "training_allow_date": ""}
+    variables = {"training_only_type": "", "training_allow_date": "", "training_allow_hidden": ""}
 
     def context(self) -> Dict:
         dictionary = super().context()

--- a/NEMO/views/training.py
+++ b/NEMO/views/training.py
@@ -29,7 +29,7 @@ def training(request):
     user: User = request.user
     users = User.objects.filter(is_active=True).exclude(id=user.id)
     hidden_allowed = TrainingCustomization.get_bool("training_allow_hidden")
-    tools = Tool.objects
+    tools = Tool.objects.all()
     if not hidden_allowed:
         tools = tools.filter(visible=True)
     tool_groups = ToolQualificationGroup.objects.all()

--- a/NEMO/views/training.py
+++ b/NEMO/views/training.py
@@ -28,7 +28,7 @@ def training(request):
     """Present a web page to allow staff or tool superusers to charge training and qualify users on particular tools."""
     user: User = request.user
     users = User.objects.filter(is_active=True).exclude(id=user.id)
-    hidden_allowed = TrainingCustomization.get_bool("training_allow_hidden")
+    hidden_allowed = TrainingCustomization.get_bool("training_allow_hidden_tools")
     tools = Tool.objects.all()
     if not hidden_allowed:
         tools = tools.filter(visible=True)

--- a/NEMO/views/training.py
+++ b/NEMO/views/training.py
@@ -28,7 +28,10 @@ def training(request):
     """Present a web page to allow staff or tool superusers to charge training and qualify users on particular tools."""
     user: User = request.user
     users = User.objects.filter(is_active=True).exclude(id=user.id)
-    tools = Tool.objects.filter(visible=True)
+    hidden_allowed = TrainingCustomization.get_bool("training_allow_hidden")
+    tools = Tool.objects
+    if not hidden_allowed:
+        tools = tools.filter(visible=True)
     tool_groups = ToolQualificationGroup.objects.all()
     if not user.is_staff and user.is_tool_superuser:
         tools = tools.filter(_superusers__in=[user])


### PR DESCRIPTION
According to suggestion in  #220, I open this PR to enable training for non-visible tools.
Training on hidden tools can now be re-enabled using the corresponding customization setting.

This can be used to track trainings for the initial induction, setting an hidden tool with Facility name.