### PR TITLE
Use the NIST-Software SPDX tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=find_namespace_packages(exclude=["resources", "resources.*", "build", "build.*"]),
     include_package_data=True,
     url="https://github.com/usnistgov/NEMO",
-    license="Public domain",
+    license="NIST-Software",
     author="Center for Nanoscale Science and Technology",
     author_email="CNSTapplications@nist.gov",
     description="NEMO is a laboratory logistics web application. Use it to schedule reservations, control tool access, track maintenance issues, and more.",


### PR DESCRIPTION
The project's license has an SPDX tag - https://spdx.org/licenses/NIST-Software.html

Updating per #225 

I haven't updated the Trove license classifier as there isn't an option that fits better than Public Domain [this software is Public Domain within the US and very permissively licensed outside of the US]