### PR TITLE
Landing page script name fix

### DIFF
--- a/NEMO/templates/landing.html
+++ b/NEMO/templates/landing.html
@@ -150,7 +150,7 @@
             {% for choice in landing_page_choices %}
                 {% if forloop.counter0|divisibleby:4 %}<div class="row">{% endif %}
                     <div class="col-md-3 text-center" style="margin-bottom:30px">
-                        <a href="{{ choice.url }}"
+                        <a href="{{ script_name }}{{ choice.url }}"
                            {% if choice.open_in_new_tab %}target="_blank" {% else %}onclick="show_spinner();"{% endif %}
                            {% if choice.secure_referral %}rel="noopener noreferrer"{% endif %}
                            style="text-decoration: none !important">

--- a/NEMO/views/landing.py
+++ b/NEMO/views/landing.py
@@ -63,6 +63,7 @@ def landing(request):
         "landing_page_choices": landing_page_choices,
         "self_log_in": able_to_self_log_in_to_area(request.user),
         "self_log_out": able_to_self_log_out_of_area(request.user),
+        "script_name": settings.FORCE_SCRIPT_NAME,
     }
     return render(request, "landing.html", dictionary)
 


### PR DESCRIPTION
Allows relative paths in landing choice urls when NEMO is deployed on a subpath with conditional urls disabled.
Fixes #249.