### PR TITLE
User documents in api

### DIFF
--- a/NEMO/serializers.py
+++ b/NEMO/serializers.py
@@ -54,6 +54,7 @@ from NEMO.models import (
     TrainingSession,
     UsageEvent,
     User,
+    UserDocuments,
 )
 
 
@@ -152,6 +153,8 @@ class AlertSerializer(FlexFieldsSerializerMixin, ModelSerializer):
 
 
 class UserSerializer(FlexFieldsSerializerMixin, ModelSerializer):
+    user_documents = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+
     class Meta:
         model = User
         exclude = ["preferences"]
@@ -159,6 +162,7 @@ class UserSerializer(FlexFieldsSerializerMixin, ModelSerializer):
             "projects": ("NEMO.serializers.ProjectSerializer", {"many": True}),
             "managed_projects": ("NEMO.serializers.ProjectSerializer", {"many": True}),
             "groups": ("NEMO.serializers.GroupSerializer", {"many": True}),
+            "user_documents": ("NEMO.serializers.UserDocumentSerializer", {"many": True}),
             "user_permissions": ("NEMO.serializers.PermissionSerializer", {"many": True}),
         }
 
@@ -175,6 +179,17 @@ class ProjectDisciplineSerializer(ModelSerializer):
     class Meta:
         model = ProjectDiscipline
         fields = "__all__"
+
+
+class UserDocumentSerializer(FlexFieldsSerializerMixin, ModelSerializer):
+    user = PrimaryKeyRelatedField(many=False, queryset=User.objects.all(), allow_null=True, required=False)
+
+    class Meta:
+        model = UserDocuments
+        fields = "__all__"
+        expandable_fields = {
+            "user": ("NEMO.serializers.UserSerializer", {"many": False, "read_only": True}),
+        }
 
 
 class ProjectSerializer(FlexFieldsSerializerMixin, ModelSerializer):

--- a/NEMO/urls.py
+++ b/NEMO/urls.py
@@ -110,6 +110,7 @@ router.register(r"tool_status", api.ToolStatusViewSet, basename="tool_status")
 router.register(r"training_sessions", api.TrainingSessionViewSet)
 router.register(r"usage_events", api.UsageEventViewSet)
 router.register(r"users", api.UserViewSet)
+router.register(r"user_documents", api.UserDocumentsViewSet)
 router.registry.sort(key=sort_urls)
 
 reservation_item_types = f'(?P<item_type>{"|".join(ReservationItemType.values())})'

--- a/NEMO/views/api.py
+++ b/NEMO/views/api.py
@@ -42,6 +42,7 @@ from NEMO.models import (
     TrainingSession,
     UsageEvent,
     User,
+    UserDocuments,
 )
 from NEMO.rest_pagination import NEMOPageNumberPagination
 from NEMO.serializers import (
@@ -82,6 +83,7 @@ from NEMO.serializers import (
     TrainingSessionSerializer,
     UsageEventSerializer,
     UserSerializer,
+    UserDocumentSerializer,
 )
 from NEMO.typing import QuerySetType
 from NEMO.utilities import export_format_datetime, remove_duplicates
@@ -211,6 +213,13 @@ class UserViewSet(ModelViewSet):
         "access_expiration": date_filters,
         "physical_access_levels": manykey_filters,
     }
+
+
+class UserDocumentsViewSet(ModelViewSet):
+    filename = "user_documents"
+    queryset = UserDocuments.objects.all()
+    serializer_class = UserDocumentSerializer
+    filterset_fields = {"id": key_filters, "user": key_filters, "name": string_filters, "display_order": number_filters}
 
 
 class ProjectDisciplineViewSet(ModelViewSet):


### PR DESCRIPTION
Adds `user_documents`  endpoint to api.
Simple user_document id is also listed under `/users/` endpoint, and can be expand with `?expand=user_documents`.
Closes #262 .

