### PR TITLE
Get template file URLs using default_storage

### DIFF
--- a/NEMO/templates/customizations/customizations_upload.html
+++ b/NEMO/templates/customizations/customizations_upload.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load custom_tags_and_filters %}
 {% with element_name=name.split|join:"_"|lower extension=extension|default:"html" %}
+    {% file_url file_name=element_name|concat:"."|concat:extension as element_file_url %}
     <form method="POST"
           action="{% url 'customize' key element_name %}#{{ element_name }}_id"
           enctype="multipart/form-data">
@@ -12,7 +13,7 @@
                    onchange="this.style.color = 'inherit';$('#{{ element_name }}_span').hide()">
             {% if element %}
                 <a id="{{ element_name }}_span"
-                   href="{% get_media_prefix %}{{ element_name }}.{{ extension }}"
+                   href="{{ element_file_url }}"
                    download="{{ element_name }}.{{ extension }}"
                    target="_blank">{{ element_link_name|default:element_name }}.{{ extension }}</a>
             {% endif %}
@@ -25,8 +26,7 @@
             </div>
             {% if element and not hide_content %}
                 <div style="display: inline-block;margin-top: 15px">
-                    {% get_media_prefix as media_prefix %}
-                    {% button type="info" url=media_prefix|concat:element_name|concat:"."|concat:extension target="_blank" value="Show current content" icon="glyphicon-eye-open" %}
+                    {% button type="info" url=element_file_url target="_blank" value="Show current content" icon="glyphicon-eye-open" %}
                 </div>
             {% endif %}
         </div>

--- a/NEMO/templates/jumbotron/jumbotron.html
+++ b/NEMO/templates/jumbotron/jumbotron.html
@@ -19,7 +19,7 @@
         <title>Jumbotron</title>
     </head>
     <body class="jumbotron-body"
-          style="{% if watermark %}background-image:linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), url('{{ MEDIA_URL }}jumbotron_watermark.png'){% endif %}">
+        style="{% if watermark %}background-image:linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), url('{% file_url file_name="jumbotron_watermark.png" %}'){% endif %}">
         <div id="jumbotron-container" style="min-height: calc(100vh - 61px); padding:10px 30px 0 30px">
             <div class="container-fluid" style="background:transparent">
                 <div class="row" id="content" style="background:transparent"></div>

--- a/NEMO/templates/safety/safety_data_sheets.html
+++ b/NEMO/templates/safety/safety_data_sheets.html
@@ -65,7 +65,7 @@
                                 <img style="display:block;
                                             width: 100%"
                                      alt="{{ hazard.name }} logo"
-                                     src="{% get_media_prefix %}{{ hazard.logo }}" />
+                                     src="{{ hazard.logo.url }}" />
                             </th>
                         {% endfor %}
                         <th class="sds-box-shadow-bottom"

--- a/NEMO/templatetags/custom_tags_and_filters.py
+++ b/NEMO/templatetags/custom_tags_and_filters.py
@@ -6,6 +6,7 @@ from urllib.parse import quote
 
 from django import template
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.storage import default_storage
 from django.shortcuts import resolve_url
 from django.template import Context, Template
 from django.template.defaultfilters import date, time
@@ -102,6 +103,12 @@ def navigation_url(url_name, description, *conditions):
         except NoReverseMatch:
             pass
     return ""
+
+
+@register.simple_tag
+def file_url(file_name):
+   if file_name and default_storage.exists(file_name):
+        return default_storage.url(file_name)
 
 
 @register.simple_tag


### PR DESCRIPTION
Hello @rptmat57,

This is a suggestion to possibly make NEMO's method of retrieving file URLs work with more storage methods. This came about because at UCI we are attempting to have files uploaded to Amazon S3 (with the help of [django-storages](https://pypi.org/project/django-storages/)). Viewing/downloading the files worked well when using `FileField` or `ImageField`, but errors occurred with the customization template files (emails, jumbotron, etc.) since they use a prefixed `MEDIA_URL`.

The change I made adds a custom template tag that utilizes `default_storage.url`. I tested that this also works with the previous way we were storing media files (locally on disk in a `media` folder). This should hopefully mean the change won't negatively affect any other NEMO users.

Please let me know if this change isn't wanted/needed or if more needs to be added.

Thank you,
Aaron