### PR TITLE
Run container image as non-root user by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,7 @@ EXPOSE 8000/tcp
 
 COPY start_NEMO_in_Docker.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start_NEMO_in_Docker.sh
+# Add non-root user
+RUN addgroup --system --gid 963 nemo && \
+    adduser --system --home /home/nemo --shell /usr/bin/bash --gid 963 --uid 963  --comment "NEMO user" nemo
 CMD ["start_NEMO_in_Docker.sh"]

--- a/start_NEMO_in_Docker.sh
+++ b/start_NEMO_in_Docker.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Exit if any of following commands fails
 set -e
 
@@ -10,11 +9,37 @@ else
     echo "No additional Python packages to install."
 fi
 
+# Set the PUID and PGID environment variables
+PUID=${PUID:-963}
+PGID=${PGID:-963}
+# Change the user and group IDs
+if [ "$PGID" -eq 0 ]; then
+    # If PGID is 0, use the root group
+    NEMO_GROUP="root"
+else
+    NEMO_GROUP="nemo"
+    groupmod -g "$PGID" "$NEMO_GROUP"
+fi
+if [ "$PUID" -eq 0 ]; then
+    # If PUID is 0, use the root user
+    NEMO_USER="root"
+else
+    NEMO_USER="nemo"
+    usermod -u "$PUID" "$NEMO_USER"
+fi
+
+# Change the ownership of the application directory
+if [ "$PUID" -ne 0 ]; then
+  chown -R nemo:nemo /nemo
+  chown -R root:nemo /etc/gunicorn_configuration.py
+fi
+echo "Running NEMO as user '${NEMO_USER}' (uid: ${PUID}), primary group '${NEMO_GROUP}' (gid: ${PGID})"
+
 # Collect static files
-django-admin collectstatic --no-input --clear
+su "${NEMO_USER}" -g "${NEMO_GROUP}" -c "django-admin collectstatic --no-input --clear"
 
 # Run migrations to create or update the database
-django-admin migrate
+su ${NEMO_USER} -c "django-admin migrate"
 
 # Run NEMO
-exec gunicorn --config=/etc/gunicorn_configuration.py NEMO.wsgi:application
+su ${NEMO_USER} -c "exec gunicorn --config=/etc/gunicorn_configuration.py NEMO.wsgi:application"


### PR DESCRIPTION
This PR introduces rootless Docker image as default.

After installing additional pip packages, the container will adjust required permissions and run both django-admin and gunicorn commands as user `nemo:nemo`.
UID and GID are 963 by default, but can be set using Docker Environment variables `PUID` and `GUID`, without need to recompile the image.

Same changes can be ported to splash_pad image, though it will also require to define logging on different file than `/var/log/journal`.

Running as non-root should have no drawback in functionality, since I had already been running rootless instances, with custom built images. This PR willl simplify non-root usage and make it default for all users, adding an extra security layer.

If really required for backward compatibility or troubleshooting, setting PUID/GUID as 0/0 will run as `root:root`.