### PR TITLE
Fix Healthcheck for subpath deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY gunicorn_configuration.py /etc/
 
 EXPOSE 8000/tcp
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD wget -qO- http://localhost:8000/health/ || exit 1
+    CMD wget -qO- http://localhost:8000${GUNICORN_SCRIPT_NAME}/health/ || exit 1
 
 COPY start_NEMO_in_Docker.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start_NEMO_in_Docker.sh


### PR DESCRIPTION
This PR fixes a bug where default healthcheck would fail when NEMO is [deployed in a subpath](https://github.com/usnistgov/NEMO/wiki/Subpath-deployment).

Fixes error: `Configuration problem: Request path &#x27;/health/&#x27; does not start with SCRIPT_NAME`