### PR TITLE
Reservation dropdown UX improvements

### DIFF
--- a/NEMO/apps/kiosk/templates/kiosk/tool_reservation.html
+++ b/NEMO/apps/kiosk/templates/kiosk/tool_reservation.html
@@ -82,7 +82,7 @@
         }
     });
 	let end_date_picker = $('#end_date').pickadate({format: "{{ pickadate_date_format }}", formatSubmit: "yyyy-mm-dd", firstDay: 1, hiddenName: true, onSet: refresh_times});
-	let start_time_picker = $('#start').pickatime({interval: {{ calendar_slot_duration }}, format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(true)});
+	let start_time_picker = $('#start').pickatime({interval: {{ calendar_slot_duration }}, format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(true), onSet: function() { end_time_picker.pickatime('picker').render(); }});
 	let end_time_picker = $('#end').pickatime({interval: {{ calendar_slot_duration }}, format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(false)});
 	function refresh_times()
     {
@@ -104,9 +104,21 @@
                     let times = unavailable_times[i];
                     let start = times[0];
                     let end = times[1];
+                    if (!is_start && date_time_selected === start)
+                    {
+                        let start_date_selected = start_date_picker.pickadate('picker').get('select');
+                        let start_time_selected_obj = start_time_picker.pickatime('picker').get('select');
+                        let start_time_selected = (start_date_selected && start_time_selected_obj)
+                            ? (start_date_selected.pick + start_time_selected_obj.pick * 60 * 1000) / 1000
+                            : null;
+                        if (start_time_selected === null || date_time_selected > start_time_selected)
+                        {
+                            return '<sp!an style="color:#000000;font-style:!it!al!ic">{{ pickadate_time_format }}</sp!an> <sm!all style="color:#e6bf00">reserv!able up to !here</sm!all>';
+                        }
+                    }
                     if (date_time_selected >= start && date_time_selected < end)
                     {
-                        return '<sp !an>{{ pickadate_time_format }}</sp !an> <sm !all> !alre!ad!y re!serve!d</sm !all>';
+                        return '<sp!an>{{ pickadate_time_format }}</sp!an> <sm!all style="color:#777777">!alre!ady reserved</sm!all>';
                     }
                 }
             }

--- a/NEMO/templates/mobile/new_reservation.html
+++ b/NEMO/templates/mobile/new_reservation.html
@@ -73,8 +73,8 @@
 		unavailable_times.push([{{ times.start|date:"U" }},{{ times.end|date:"U" }}]);
 		{% endfor %}
 		let date_picker = $('#date').pickadate({format: "{{ pickadate_date_format }}", formatSubmit: "yyyy-mm-dd", firstDay: 1, hiddenName: true, onSet: refresh_times});
-		let start_time_picker = $('#start').pickatime({interval: {{ calendar_slot_duration }},  format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_label});
-		let end_time_picker = $('#end').pickatime({interval: {{ calendar_slot_duration }}, format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_label});
+		let start_time_picker = $('#start').pickatime({interval: {{ calendar_slot_duration }},  format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(true), onSet: function() { end_time_picker.pickatime('picker').render(); }});
+		let end_time_picker = $('#end').pickatime({interval: {{ calendar_slot_duration }}, format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(false)});
 		// set initial date
 		if ('{{ date|default_if_none:'' }}')
 		{
@@ -85,22 +85,37 @@
             start_time_picker.pickatime('picker').render();
             end_time_picker.pickatime('picker').render();
         }
-        function format_label(time)
+        function format_labels(is_start)
         {
-		    if (date_picker.pickadate('picker').get('select') && unavailable_times.length > 0) {
-				let date_selected = date_picker.pickadate('picker').get('select').pick; // selected date in milliseconds
-				let time_selected = time.pick * 60 * 1000; // time in milliseconds
-				let date_time_selected = (date_selected + time_selected)/1000; // back to seconds to compare with python timestamp
-				for (let i=0 ; i < unavailable_times.length; i++) {
-                    let times = unavailable_times[i];
-                    let start = times[0];
-                    let end = times[1];
-                    if (date_time_selected >= start && date_time_selected < end) {
-                        return '<sp !an>{{ pickadate_time_format }}</sp !an> <sm !all> !alre!ad!y re!serve!d</sm !all>';
+            return function format_label(time)
+            {
+                if (date_picker.pickadate('picker').get('select') && unavailable_times.length > 0)
+                {
+                    let date_selected = date_picker.pickadate('picker').get('select').pick; // selected date in milliseconds
+                    let time_selected = time.pick * 60 * 1000; // time in milliseconds
+                    let date_time_selected = (date_selected + time_selected)/1000; // back to seconds to compare with python timestamp
+                    for (let i=0 ; i < unavailable_times.length; i++)
+                    {
+                        let times = unavailable_times[i];
+                        let start = times[0];
+                        let end = times[1];
+                        if (!is_start && date_time_selected === start)
+                        {
+                            let selected_start = start_time_picker.pickatime('picker').get('select');
+                            let start_time_selected = selected_start ? (date_selected + selected_start.pick * 60 * 1000) / 1000 : null;
+                            if (start_time_selected === null || date_time_selected > start_time_selected)
+                            {
+                                return '<sp!an style="color:#000000;font-style:!it!al!ic">{{ pickadate_time_format }}</sp!an> <sm!all style="color:#e6bf00">reserv!able up to !here</sm!all>';
+                            }
+                        }
+                        if (date_time_selected >= start && date_time_selected < end)
+                        {
+                            return '<sp!an>{{ pickadate_time_format }}</sp!an> <sm!all style="color:#777777">!alre!ady reserved</sm!all>';
+                        }
                     }
                 }
-			}
-		    return "{{ pickadate_time_format }}";
+                return '{{ pickadate_time_format }}';
+            }
         }
 	
     </script>


### PR DESCRIPTION
This is a small UI improvement to the reservation dropdown shown on mobile devices when creating a reservation to make it more clear what a user can reserve. For example, if a tool is reserved from 12:00 PM-1:00 PM and from 2:00 PM-2:45 PM, a user is able to make a reservation from 1:00 PM-2:00 PM but is shown that 2:00 PM is unreservable from the dropdown, which is a bit unclear as choosing 2PM is a valid option as the end time.

| Current dropdown |
| -------------------- |
| <img width="200" src="https://github.com/user-attachments/assets/9ca48e18-cdd6-4823-83ba-bedd73687330" /> |

This pull request changes the menu to more clearly display reservations for each time, as well as showing the nearest time that is still bookable as an end time once you've picked a start time.

| Setting the start time to 1PM | Selecting the end time afterwards |
| ------------- | ------------- |
| <img width="200" src="https://github.com/user-attachments/assets/2fd8642e-a55a-4c62-8b0f-97a2be9c0e5f" /> | <img width="200" src="https://github.com/user-attachments/assets/177592e4-bfe6-43b3-8ccb-1c81f20e2977" /> |




