### PR TITLE
Add maintenance filters and ordering (resolves #92)

### DIFF
--- a/NEMO/templates/maintenance/maintenance.html
+++ b/NEMO/templates/maintenance/maintenance.html
@@ -24,7 +24,7 @@
             <div class="split-screen-left-panel">
                 <div class="form-inline" style="margin: 15px;">
                     <label class="form-group control-label text-left" for="tool_category_search_pending">Tool category:</label>
-                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 60%; min-width: 150px;">
+                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 25%; min-width: 150px;">
                         <input id="tool_category_search_pending"
                                type="text"
                                class="form-group form-control tool-category-search"
@@ -32,30 +32,76 @@
                                value="{{ tool_category|default_if_none:'' }}"
                                style="width: 100%" />
                     </div>
+                    <label class="form-group control-label text-left" for="tool_search_pending" style="margin-left: 15px;">Tool:</label>
+                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 25%; min-width: 150px;">
+                        <input id="tool_search_pending"
+                               type="text"
+                               class="form-group form-control tool-search"
+                               placeholder="Filter by specific tool"
+                               value="{{ selected_tool.name|default_if_none:'' }}"
+                               style="width: 100%" />
+                    </div>
+                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 25%; min-width: 150px;">
+                        <div class="input-group" style="width: 100%">
+                            <input id="maintenance_search_pending"
+                                   type="text"
+                                   class="form-control maintenance-search"
+                                   placeholder="Search title and descriptions"
+                                   value="{{ search|default_if_none:'' }}"
+                                   onkeydown="if(event.key === 'Enter'){ apply_maintenance_search('pending'); return false; }">
+                            <span class="input-group-btn">
+                                <button class="btn btn-default" type="button" onclick="apply_maintenance_search('pending')">
+                                    <span class="glyphicon glyphicon-search"></span>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
                 </div>
                 <table id="pending_tasks" class="table table-hover">
                     <thead>
                         <tr>
+                            {% url 'maintenance' as pending_sort_base_url %}
                             <th>
-                                <a href="{% url 'maintenance' sort_by='urgency' %}">Urgency</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=urgency">
+                                    Urgency
+                                    <span class="{% if pending_sort_by != 'urgency' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>
-                                <a href="{% url 'maintenance' sort_by='force_shutdown' %}">Severity</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=force_shutdown">
+                                    Severity
+                                    <span class="{% if pending_sort_by != 'force_shutdown' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>
-                                <a href="{% url 'maintenance' sort_by='tool' %}">Tool</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=tool">
+                                    Tool
+                                    <span class="{% if pending_sort_by != 'tool' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>
-                                <a href="{% url 'maintenance' sort_by='tool___category' %}">Tool category</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=tool___category">
+                                    Tool category
+                                    <span class="{% if pending_sort_by != 'tool___category' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>
-                                <a href="{% url 'maintenance' sort_by='problem_category' %}">Problem category</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=problem_category">
+                                    Problem category
+                                    <span class="{% if pending_sort_by != 'problem_category' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>
-                                <a href="{% url 'maintenance' sort_by='last_updated' %}">Last updated</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=last_updated">
+                                    Last updated
+                                    <span class="{% if pending_sort_by != 'last_updated' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>
-                                <a href="{% url 'maintenance' sort_by='creation_time' %}">Created</a>
+                                <a style="display:flex;align-items:center" href="{{ pending_sort_base_url }}?{% if pending_extra_params %}{{ pending_extra_params }}&{% endif %}tab=pending&sort_by=creation_time">
+                                    Created
+                                    <span class="{% if pending_sort_by != 'creation_time' %}invisible{% endif %} glyphicon glyphicon-triangle-bottom"></span>
+                                </a>
                             </th>
                             <th>Description</th>
                         </tr>
@@ -82,6 +128,10 @@
                             <td>{{ task.creation_time|naturaltime }}</td>
                             <td>{{ task.problem_description }}</td>
                         </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="8">No maintenance records match your filters.</td>
+                        </tr>
                     {% endfor %}
                 </table>
             </div>
@@ -91,7 +141,7 @@
             <div class="split-screen-left-panel">
                 <div class="form-inline" style="margin: 15px;">
                     <label class="form-group control-label text-left" for="tool_category_search_closed">Tool category:</label>
-                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 60%; min-width: 150px;">
+                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 25%; min-width: 150px;">
                         <input id="tool_category_search_closed"
                                type="text"
                                class="form-group form-control tool-category-search"
@@ -99,21 +149,53 @@
                                value="{{ tool_category|default_if_none:'' }}"
                                style="width: 100%" />
                     </div>
+                    <label class="form-group control-label text-left" for="tool_search_closed" style="margin-left: 15px;">Tool:</label>
+                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 25%; min-width: 150px;">
+                        <input id="tool_search_closed"
+                               type="text"
+                               class="form-group form-control tool-search"
+                               placeholder="Filter by specific tool"
+                               value="{{ selected_tool.name|default_if_none:'' }}"
+                               style="width: 100%" />
+                    </div>
+                    <div class="form-group" style="display: inline-block;margin-left: 15px;width: 25%; min-width: 150px;">
+                        <div class="input-group" style="width: 100%">
+                            <input id="maintenance_search_closed"
+                                   type="text"
+                                   class="form-control maintenance-search"
+                                   placeholder="Search title and descriptions"
+                                   value="{{ search|default_if_none:'' }}"
+                                   onkeydown="if(event.key === 'Enter'){ apply_maintenance_search('closed'); return false; }">
+                            <span class="input-group-btn">
+                                <button class="btn btn-default" type="button" onclick="apply_maintenance_search('closed')">
+                                    <span class="glyphicon glyphicon-search"></span>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
                 </div>
                 <table id="closed_tasks" class="table table-hover">
                     <thead>
                         <tr>
-                            <th>Urgency</th>
+                            <th>
+                                {% include 'pagination/pagination_column.html' with page=closed_page extra_params=closed_extra_params order_by='urgency' name='Urgency' %}
+                            </th>
                             <th>Severity</th>
-                            <th>Tool</th>
+                            <th>
+                                {% include 'pagination/pagination_column.html' with page=closed_page extra_params=closed_extra_params order_by='tool__name' name='Tool' %}
+                            </th>
                             <th>Tool category</th>
                             <th>Problem category</th>
-                            <th>Created</th>
-                            <th>Resolved</th>
+                            <th>
+                                {% include 'pagination/pagination_column.html' with page=closed_page extra_params=closed_extra_params order_by='creation_time' name='Created' %}
+                            </th>
+                            <th>
+                                {% include 'pagination/pagination_column.html' with page=closed_page extra_params=closed_extra_params order_by='resolution_time' name='Resolved' %}
+                            </th>
                             <th>Description</th>
                         </tr>
                     </thead>
-                    {% for task in closed_tasks %}
+                    {% for task in closed_page %}
                         <tr onclick="closed_task_details(this, '{% url 'task_details' task.id %}')">
                             <td>{{ task.get_urgency_display }}</td>
                             <td>
@@ -130,8 +212,18 @@
                             <td>{{ task.resolution_time }}</td>
                             <td>{{ task.problem_description }}</td>
                         </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="8">No maintenance records match your filters.</td>
+                        </tr>
                     {% endfor %}
                 </table>
+                <div class="pagination pull-left">
+                    {% include 'pagination/pagination_selector.html' with page=closed_page paginator=closed_page.paginator extra_params=closed_extra_params %}
+                </div>
+                <div class="pagination pull-right">
+                    {% include 'pagination/pagination_pages.html' with page=closed_page paginator=closed_page.paginator extra_params=closed_extra_params %}
+                </div>
             </div>
             <div id="closed_task_details" class="split-screen-right-panel"></div>
         </div>
@@ -208,6 +300,37 @@
         window.location.href = this_url.toString();
     }
 
+    function filter_tool(jquery_event, search_selection)
+    {
+        const this_url = new URL(window.location.href);
+        if (search_selection.id)
+        {
+            this_url.searchParams.set("tool", search_selection.id);
+        }
+        else
+        {
+            this_url.searchParams.delete("tool");
+        }
+        this_url.searchParams.set("tab", $("#tabs li.active a").attr("href").substring(1));
+        window.location.href = this_url.toString();
+    }
+
+    function apply_maintenance_search(tab)
+    {
+        const this_url = new URL(window.location.href);
+        let search_value = $("#maintenance_search_" + tab).val();
+        if (search_value)
+        {
+            this_url.searchParams.set("search", search_value);
+        }
+        else
+        {
+            this_url.searchParams.delete("search");
+        }
+        this_url.searchParams.set("tab", tab);
+        window.location.href = this_url.toString();
+    }
+
 	function on_load()
 	{
 		$("#tabs a").click(switch_tab);
@@ -224,6 +347,15 @@
             if (!$(this).val())
             {
                 filter_tool_category('', {'name': ''});
+            }
+        });
+        $(".tool-search")
+        .autocomplete('tools', filter_tool, {{ tools|json_search_base }}, true)
+        .on("input", function ()
+        {
+            if (!$(this).val())
+            {
+                filter_tool('', {'id': ''});
             }
         });
 

--- a/NEMO/templates/pagination/pagination_pages.html
+++ b/NEMO/templates/pagination/pagination_pages.html
@@ -2,22 +2,22 @@
     {% if page.has_previous %}
         {# check if we need to call a js function or refresh the current page #}
         {% if page.paginator.js_callback %}
-            <a href="javascript:{{ paginator.js_callback }}('o={{ paginator.order_by }}&p=1&pp={{ paginator.per_page }}')">&laquo; first</a>
-            <a href="javascript:{{ paginator.js_callback }}('o={{ paginator.order_by }}&p={{ page.previous_page_number }}&pp={{ paginator.per_page }}')">previous</a>
+            <a href="javascript:{{ paginator.js_callback }}('{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p=1&pp={{ paginator.per_page }}')">&laquo; first</a>
+            <a href="javascript:{{ paginator.js_callback }}('{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ page.previous_page_number }}&pp={{ paginator.per_page }}')">previous</a>
         {% else %}
-            <a href="?o={{ paginator.order_by }}&p=1&pp={{ paginator.per_page }}">&laquo; first</a>
-            <a href="?o={{ paginator.order_by }}&p={{ page.previous_page_number }}&pp={{ paginator.per_page }}">previous</a>
+            <a href="?{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p=1&pp={{ paginator.per_page }}">&laquo; first</a>
+            <a href="?{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ page.previous_page_number }}&pp={{ paginator.per_page }}">previous</a>
         {% endif %}
     {% endif %}
     <span class="current">Page {{ page.number }} of {{ paginator.num_pages }}</span>
     {% if page.has_next %}
         {# check if we need to call a js function or refresh the current page #}
         {% if page.paginator.js_callback %}
-            <a href="javascript:{{ paginator.js_callback }}('o={{ paginator.order_by }}&p={{ page.next_page_number }}&pp={{ paginator.per_page }}')">next</a>
-            <a href="javascript:{{ paginator.js_callback }}('o={{ paginator.order_by }}&p={{ paginator.num_pages }}&pp={{ paginator.per_page }}')">last &raquo;</a>
+            <a href="javascript:{{ paginator.js_callback }}('{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ page.next_page_number }}&pp={{ paginator.per_page }}')">next</a>
+            <a href="javascript:{{ paginator.js_callback }}('{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ paginator.num_pages }}&pp={{ paginator.per_page }}')">last &raquo;</a>
         {% else %}
-            <a href="?o={{ paginator.order_by }}&p={{ page.next_page_number }}&pp={{ paginator.per_page }}">next</a>
-            <a href="?o={{ paginator.order_by }}&p={{ paginator.num_pages }}&pp={{ paginator.per_page }}">last &raquo;</a>
+            <a href="?{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ page.next_page_number }}&pp={{ paginator.per_page }}">next</a>
+            <a href="?{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ paginator.num_pages }}&pp={{ paginator.per_page }}">last &raquo;</a>
         {% endif %}
     {% endif %}
 </span>

--- a/NEMO/templates/pagination/pagination_selector.html
+++ b/NEMO/templates/pagination/pagination_selector.html
@@ -1,5 +1,5 @@
 <select id="results_per_page"
-        onchange="{% if paginator.js_callback %}{{ paginator.js_callback }}({% else %}window.location = {% endif %}'?o={{ paginator.order_by }}&p={{ page.number }}&pp='+this.value{% if paginator.js_callback %}){% endif %}">
+        onchange="{% if paginator.js_callback %}{{ paginator.js_callback }}({% else %}window.location = {% endif %}'?{% if extra_params %}{{ extra_params }}&{% endif %}o={{ paginator.order_by }}&p={{ page.number }}&pp='+this.value{% if paginator.js_callback %}){% endif %}">
     <option value="5" {% if paginator.per_page == 5 %}selected{% endif %}>5</option>
     <option value="25" {% if paginator.per_page == 25 %}selected{% endif %}>25</option>
     <option value="50" {% if paginator.per_page == 50 %}selected{% endif %}>50</option>

--- a/NEMO/views/maintenance.py
+++ b/NEMO/views/maintenance.py
@@ -1,4 +1,5 @@
 from itertools import chain
+from urllib.parse import urlencode
 
 from django.db.models import Q
 from django.http import HttpResponseNotFound
@@ -6,29 +7,60 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_GET
 
 from NEMO.decorators import staff_member_or_tool_staff_required
-from NEMO.models import Task, TaskCategory, TaskStatus, User
+from NEMO.models import Task, TaskCategory, TaskStatus, Tool, User
 from NEMO.utilities import as_timezone, get_tool_categories_for_filters
+from NEMO.views.pagination import SortedPaginator
+
+CLOSED_TASK_SORT_FIELDS = {
+    "creation_time",
+    "-creation_time",
+    "resolution_time",
+    "-resolution_time",
+    "tool__name",
+    "-tool__name",
+    "urgency",
+    "-urgency",
+}
+
+
+def filter_maintenance_records(tasks, tool_category: str, tool_id: str, search: str):
+    if tool_category:
+        tasks = tasks.filter(Q(tool___category=tool_category) | (Q(tool___category__startswith=tool_category + "/")))
+    if tool_id:
+        tasks = tasks.filter(tool_id=tool_id)
+    if search:
+        tasks = tasks.filter(
+            Q(problem_description__icontains=search)
+            | Q(progress_description__icontains=search)
+            | Q(resolution_description__icontains=search)
+            | Q(tool__name__icontains=search)
+        )
+    return tasks
 
 
 @staff_member_or_tool_staff_required
 @require_GET
 def maintenance(request, sort_by=""):
+    # The "sort_by" URL path segment is kept only for backwards compatibility with old bookmarks/links.
+    # New links use the "sort_by" query parameter instead, so the browser never navigates away from the
+    # plain "/maintenance/" path -- otherwise the closed tab's sort/pagination links (which are relative
+    # "?..." hrefs) end up resolving against a lingering "/maintenance/<sort_by>/" path and get "stuck".
+    sort_by = sort_by or request.GET.get("sort_by", "")
     user: User = request.user
     pending_tasks = Task.objects.filter(cancelled=False, resolved=False)
     if not user.is_staff:
         # restrict to tools that the user is staff for
         pending_tasks = pending_tasks.filter(tool__in=user.staff_for_tools.all())
     tool_category = request.GET.get("tool_category")
+    tool_id = request.GET.get("tool")
+    search = request.GET.get("search", "").strip()
     if user.get_preferences().tool_task_notifications.exists():
         # Limit tools to preferences + tools user is the owner of + tools user is a backup owner of.
         limit_tools = set(user.get_preferences().tool_task_notifications.all())
         limit_tools.update(user.primary_tool_owner.all())
         limit_tools.update(user.backup_for_tools.all())
         pending_tasks = pending_tasks.filter(tool__in=limit_tools)
-    if tool_category:
-        pending_tasks = pending_tasks.filter(
-            Q(tool___category=tool_category) | (Q(tool___category__startswith=tool_category + "/"))
-        )
+    pending_tasks = filter_maintenance_records(pending_tasks, tool_category, tool_id, search)
     if sort_by in [
         "urgency",
         "force_shutdown",
@@ -40,9 +72,9 @@ def maintenance(request, sort_by=""):
     ]:
         if sort_by == "last_updated":
             pending_tasks = pending_tasks.exclude(last_updated=None).order_by("-last_updated")
-            not_yet_updated_tasks = Task.objects.filter(cancelled=False, resolved=False, last_updated=None).order_by(
-                "-creation_time"
-            )
+            not_yet_updated_tasks = filter_maintenance_records(
+                Task.objects.filter(cancelled=False, resolved=False, last_updated=None), tool_category, tool_id, search
+            ).order_by("-creation_time")
             pending_tasks = list(chain(pending_tasks, not_yet_updated_tasks))
         else:
             pending_tasks = pending_tasks.order_by(sort_by)
@@ -50,22 +82,52 @@ def maintenance(request, sort_by=""):
                 pending_tasks = pending_tasks.reverse()
     else:
         pending_tasks = pending_tasks.order_by("urgency").reverse()  # Order by urgency by default
-    closed_tasks = (
-        Task.objects.filter(Q(cancelled=True) | Q(resolved=True))
-        .exclude(resolution_time__isnull=True)
-        .order_by("-resolution_time")
+
+    closed_tasks = Task.objects.filter(Q(cancelled=True) | Q(resolved=True)).exclude(resolution_time__isnull=True)
+    closed_tasks = filter_maintenance_records(closed_tasks, tool_category, tool_id, search)
+    closed_order_by = request.GET.get("o")
+    if closed_order_by not in CLOSED_TASK_SORT_FIELDS:
+        # SortedPaginator reads "o" straight from request.GET, so an invalid value has to be
+        # corrected there too, not just in the default we pass in below
+        closed_order_by = "-resolution_time"
+        sanitized_get = request.GET.copy()
+        sanitized_get["o"] = closed_order_by
+        request.GET = sanitized_get
+    closed_paginator = SortedPaginator(closed_tasks, request, order_by=closed_order_by)
+    closed_page = closed_paginator.get_current_page()
+
+    closed_extra_params = urlencode(
+        {
+            key: value
+            for key, value in {
+                "tool_category": tool_category,
+                "tool": tool_id,
+                "search": search,
+                "tab": "closed",
+            }.items()
+            if value
+        }
     )
-    if tool_category:
-        closed_tasks = closed_tasks.filter(
-            Q(tool___category=tool_category) | (Q(tool___category__startswith=tool_category + "/"))
-        )
-    closed_tasks = closed_tasks[:20]
+    pending_extra_params = urlencode(
+        {
+            key: value
+            for key, value in {"tool_category": tool_category, "tool": tool_id, "search": search}.items()
+            if value
+        }
+    )
+
     dictionary = {
         "pending_tasks": pending_tasks,
-        "closed_tasks": closed_tasks,
+        "closed_page": closed_page,
+        "closed_extra_params": closed_extra_params,
+        "pending_extra_params": pending_extra_params,
         "tool_categories": get_tool_categories_for_filters(),
+        "tools": Tool.objects.all().order_by("name"),
         "tool_category": tool_category,
+        "selected_tool": Tool.objects.filter(id=tool_id).first() if tool_id else None,
+        "search": search,
         "tab": request.GET.get("tab", "pending"),
+        "pending_sort_by": sort_by,
     }
     return render(request, "maintenance/maintenance.html", dictionary)
 


### PR DESCRIPTION
This pull requests adds two new search options to the maintenance page to quickly filter by tool, search by description, and order by task opening and resolution time. This resolves #92. 

<img width="1173" height="453" alt="image" src="https://github.com/user-attachments/assets/5db5d0e2-ff89-4889-883a-7a855cd15100" />

NOTE: This builds on, but doesn't require, #325. It should also search through titles. Just change the following in `NEMO/views/maintenance.py` LOC 32-37:

```py
        tasks = tasks.filter(
            Q(problem_description__icontains=search)
            | Q(progress_description__icontains=search)
            | Q(resolution_description__icontains=search)
            | Q(tool__name__icontains=search)
        )
``` 

to:

```py
        tasks = tasks.filter(
            Q(title__icontains=search)
            | Q(problem_description__icontains=search)
            | Q(progress_description__icontains=search)
            | Q(resolution_description__icontains=search)
            | Q(tool__name__icontains=search)
        )
```

This can be done after merging or in the code review stage. Thanks! 