### PR TITLE
Reservation question editing (resolves #153)

### DIFF
--- a/NEMO/models.py
+++ b/NEMO/models.py
@@ -2283,7 +2283,7 @@ class Tool(SerializationByNameModel):
             ]
         )
 
-    def get_reservation_questions(self, project: Project = None) -> MultiDynamicForms:
+    def get_reservation_questions(self, project: Project = None, initial_data: str = None) -> MultiDynamicForms:
         from NEMO.widgets.dynamic_form import MultiDynamicForms
 
         reservation_questions = ReservationQuestions.objects.filter(enabled=True)
@@ -2297,7 +2297,7 @@ class Tool(SerializationByNameModel):
             )
         else:
             reservation_questions = reservation_questions.filter(only_for_projects=None)
-        return MultiDynamicForms(reservation_questions)
+        return MultiDynamicForms(reservation_questions, initial_data=initial_data)
 
     def _get_usage_questions(self, questions_type: str, user: User, project: Project) -> QuerySetType:
         real_id = self.tool_or_parent_id()
@@ -3029,7 +3029,7 @@ class Area(MPTTModel):
             email for area in self.get_ancestors(ascending=True, include_self=True) for email in area.reservation_email
         ]
 
-    def get_reservation_questions(self, project: Project = None) -> MultiDynamicForms:
+    def get_reservation_questions(self, project: Project = None, initial_data: str = None) -> MultiDynamicForms:
         from NEMO.widgets.dynamic_form import MultiDynamicForms
 
         reservation_questions = ReservationQuestions.objects.filter(enabled=True)
@@ -3041,7 +3041,7 @@ class Area(MPTTModel):
             )
         else:
             reservation_questions = reservation_questions.filter(only_for_projects=None)
-        return MultiDynamicForms(reservation_questions)
+        return MultiDynamicForms(reservation_questions, initial_data=initial_data)
 
     @property
     def location(self):

--- a/NEMO/templates/calendar/reservation_questions.html
+++ b/NEMO/templates/calendar/reservation_questions.html
@@ -1,10 +1,18 @@
 {% load custom_tags_and_filters %}
 <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-label="Modal close button">&times;</button>
-    <h4 id="modal-description-label" class="modal-title">Reservation questions</h4>
+    <h4 id="modal-description-label" class="modal-title">
+        {% if editing_reservation_id %}Edit reservation answers{% else %}Reservation questions{% endif %}
+    </h4>
 </div>
 <div class="modal-body">
-    <p>This reservation requires extra information to be provided:</p>
+    <p>
+        {% if editing_reservation_id %}
+            You may update your answers to this reservation's questions below:
+        {% else %}
+            This reservation requires extra information to be provided:
+        {% endif %}
+    </p>
     {% if error %}
         <div class="alert alert-danger">
             Oops! Something went wrong. Please correct the errors highlighted below.
@@ -23,7 +31,12 @@
 </div>
 <div class="modal-footer">
     <p id="answer_to_proceed" style="text-align:center">Please answer the required questions (above) to proceed</p>
-    {% button id="reservation_questions_submit" type="save" value="Submit" dismiss="modal" onclick="$('#dialog_cancelled').val(false);" submit=False %}
+    {% if editing_reservation_id %}
+        {% url 'edit_reservation_questions' editing_reservation_id as edit_reservation_questions_url %}
+        {% button id="reservation_questions_submit" type="save" value="Save answers" submit=False onclick="save_reservation_question_answers('"|concat:edit_reservation_questions_url|concat:"');" %}
+    {% else %}
+        {% button id="reservation_questions_submit" type="save" value="Submit" dismiss="modal" onclick="$('#dialog_cancelled').val(false);" submit=False %}
+    {% endif %}
 </div>
 <script>
 	function update_submit_button()
@@ -42,4 +55,25 @@
 
 	update_submit_button();
     $('body').on('dynamic-form-group-changed dynamic-form-field-changed', update_submit_button);
+    $('#dialog .modal-dialog').addClass('modal-lg');
+
+    {% if editing_reservation_id %}
+        function save_reservation_question_answers(url)
+        {
+            let post_data = $("#additional_event_parameters").serialize();
+            ajax_post(url, post_data, function(response, status, xml_http_request)
+            {
+                if (response)
+                {
+                    {# Validation failed server-side, so re-render the dialog with the error and previous answers #}
+                    $("#dialog .modal-content").html(response);
+                }
+                else
+                {
+                    $("#dialog").modal('hide');
+                    refresh_calendar_and_sidebar();
+                }
+            }, ajax_failure_callback("Unable to save the reservation questions"));
+        }
+    {% endif %}
 </script>

--- a/NEMO/templates/event_details/reservation_details.html
+++ b/NEMO/templates/event_details/reservation_details.html
@@ -243,7 +243,14 @@
 {% endif %}
 {% if reservation.question_data_json.items %}
     <tr>
-        <td>Reservation questions:</td>
+        <td style="vertical-align: middle">
+            Reservation questions:
+            {% if reservation_questions_can_be_edited %}
+                <span class="glyphicon glyphicon-pencil pull-right"
+                      title="Edit answers"
+                      onclick="ajax_get('{% url 'edit_reservation_questions' reservation.id %}', undefined, ajax_success_callback)"></span>
+            {% endif %}
+        </td>
         <td style="padding: 0;">
             <table class="table table-striped" style="margin-bottom: 0;">
                 {% for question_name, data in reservation.question_data_json.items %}

--- a/NEMO/urls.py
+++ b/NEMO/urls.py
@@ -345,6 +345,11 @@ urlpatterns += [
         calendar.change_reservation_note,
         name="change_reservation_note",
     ),
+    path(
+        "edit_reservation_questions/<int:reservation_id>/",
+        calendar.edit_reservation_questions,
+        name="edit_reservation_questions",
+    ),
     path("change_outage_title/<int:outage_id>/", calendar.change_outage_title, name="change_outage_title"),
     path("change_outage_details/<int:outage_id>/", calendar.change_outage_details, name="change_outage_details"),
     path("change_reservation_date/", calendar.change_reservation_date, name="change_reservation_date"),

--- a/NEMO/views/calendar.py
+++ b/NEMO/views/calendar.py
@@ -12,7 +12,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import make_aware
-from django.views.decorators.http import require_GET, require_POST
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 
 from NEMO.constants import ADDITIONAL_INFORMATION_MAXIMUM_LENGTH
 from NEMO.decorators import disable_session_expiry_refresh, postpone, staff_member_or_tool_staff_required, synchronized
@@ -864,6 +864,44 @@ def change_reservation_note(request, reservation_id):
     reservation.note = request.POST.get("note", "")
     reservation.save_and_notify()
     return HttpResponse()
+
+
+@login_required
+@require_http_methods(["GET", "POST"])
+def edit_reservation_questions(request, reservation_id):
+    """
+    Let a reservation's owner (or staff on the tool) re-answer the reservation questions for an
+    upcoming or in-progress reservation, pre-filled with the answers that were previously given.
+    """
+    reservation = get_object_or_404(Reservation, id=reservation_id)
+    if not (request.user == reservation.user or request.user.is_staff_on_tool(reservation.tool)):
+        return HttpResponseBadRequest("You are not allowed to edit this reservation.")
+    if reservation.cancelled or reservation.missed:
+        return HttpResponseBadRequest("This reservation has been cancelled and its questions can no longer be edited.")
+    if not reservation.has_not_ended():
+        return HttpResponseBadRequest("You cannot edit the questions for a reservation that has already ended.")
+
+    dynamic_forms = reservation.reservation_item.get_reservation_questions(
+        reservation.project, initial_data=reservation.question_data
+    )
+    if not dynamic_forms:
+        return HttpResponseBadRequest("This reservation does not have any questions to edit.")
+
+    if request.method == "POST":
+        try:
+            reservation.question_data = dynamic_forms.extract(request)
+            reservation.save()
+            return HttpResponse()
+        except RequiredUnansweredQuestionsException as e:
+            dictionary = {
+                "error": str(e),
+                "reservation_questions": dynamic_forms.render(),
+                "editing_reservation_id": reservation.id,
+            }
+            return render(request, "calendar/reservation_questions.html", dictionary)
+
+    dictionary = {"reservation_questions": dynamic_forms.render(), "editing_reservation_id": reservation.id}
+    return render(request, "calendar/reservation_questions.html", dictionary)
 
 
 @staff_member_or_tool_staff_required

--- a/NEMO/views/event_details.py
+++ b/NEMO/views/event_details.py
@@ -19,14 +19,20 @@ def reservation_details(request, reservation_id):
         return HttpResponseNotFound(error_message)
     reservation_project_can_be_changed = (
         (request.user.is_staff or request.user.is_staff_on_tool(reservation.tool) or request.user == reservation.user)
-        and reservation.has_not_ended
-        and reservation.has_not_started
+        and reservation.has_not_ended()
+        and reservation.has_not_started()
         and reservation.user.active_project_count() > 1
+    )
+    reservation_questions_can_be_edited = (
+        not reservation.missed
+        and reservation.has_not_ended()
+        and (request.user == reservation.user or request.user.is_staff_on_tool(reservation.tool))
     )
 
     template_data = {
         "reservation": reservation,
         "reservation_project_can_be_changed": reservation_project_can_be_changed,
+        "reservation_questions_can_be_edited": reservation_questions_can_be_edited,
         "popup_view": popup_view,
     }
 


### PR DESCRIPTION
This pull request introduces the ability to edit future reservation questions if you are the user reserving or if you are a superadmin/staff. Below is a video demonstration showing past reservations unable to be edited, and editing a future reservation (showing the changes saved.) This resolves #153.

https://github.com/user-attachments/assets/43c6ef4f-78a2-47a2-8fb6-7f07813671a3


