### PR TITLE
Allow task creators to append notes (resolves #190)

### DIFF
--- a/NEMO/apps/kiosk/templates/kiosk/tool_information.html
+++ b/NEMO/apps/kiosk/templates/kiosk/tool_information.html
@@ -236,6 +236,26 @@
                                 </div>
                             </div>
                         {% endif %}
+                        {% with update_permission=customizations|get_item:"tool_problem_update_permission" %}
+                            {% if customer.id == t.creator.id or customer in tool.superusers.all or update_permission == "all" or update_permission == "staff" and user_qualifies_for_task_updates %}
+                                <div class="media">
+                                    <span class="glyphicon glyphicon-plus-sign pull-left notification-icon success-highlight"></span>
+                                    <div class="media-body">
+                                        <a onclick="$(this).hide();$('#task_{{ t.id }}_add_info').show();" class="pointer">Add more information</a>
+                                        <div id="task_{{ t.id }}_add_info" style="display: none">
+                                            <textarea id="task_{{ t.id }}_additional_info"
+                                                      class="form-control"
+                                                      placeholder="Add more information about this problem."></textarea>
+                                            <button class="btn btn-success"
+                                                    style="margin-top:5px"
+                                                    onclick="add_task_information('{% url 'add_task_information' t.id %}', $('#task_{{ t.id }}_additional_info').val())">
+                                                Add
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        {% endwith %}
                     </div>
                 </div>
             </div>
@@ -564,6 +584,19 @@
 {% endif %}
 <div style="height:150px">{# Spacer #}</div>
 <script>
+	function add_task_information(url, description)
+	{
+		if (!description || !description.trim())
+		{
+			return;
+		}
+		let failure_dialog = ajax_failure_callback("Unable to add information to this task");
+		ajax_post(url, {'description': description}, function()
+		{
+			tool_information('{% url 'kiosk_tool_information' tool.id customer.id back %}');
+		}, [failure_dialog]);
+	}
+
 	update_stop_button();
 	{% if customer.active_projects|length == 1 %}update_start_button();{% endif %}
 

--- a/NEMO/apps/kiosk/views.py
+++ b/NEMO/apps/kiosk/views.py
@@ -529,6 +529,12 @@ def tool_information(request, tool_id, user_id, back):
         ),
         "back": back,
         "tool_control_show_task_details": ToolControlCustomization.get_bool("tool_control_show_task_details"),
+        "user_qualifies_for_task_updates": (
+            customer.is_staff_on_tool(tool)
+            or customer.id == tool.primary_owner_id
+            or customer in tool.backup_owners.all()
+            or customer.is_superuser
+        ),
         "wait_list_position": user_wait_list_position,  # 0 if not in wait list
         "wait_list": wait_list,
         "show_wait_list": (

--- a/NEMO/templates/customizations/customizations_tool.html
+++ b/NEMO/templates/customizations/customizations_tool.html
@@ -266,7 +266,7 @@
         <div class="form-group">
             <label class="control-label col-sm-4 col-md-3">Who can add updates</label>
             <div class="col-sm-8 col-md-9">
-                <div class="radio">
+                <div class="radio" role="group" aria-labelledby="tool_problem_update_permission">
                     <label>
                         <input type="radio"
                                name="tool_problem_update_permission"
@@ -274,8 +274,7 @@
                                value="creator">
                         Only the task creator
                     </label>
-                </div>
-                <div class="radio">
+                    <br>
                     <label>
                         <input type="radio"
                                name="tool_problem_update_permission"
@@ -283,8 +282,7 @@
                                value="staff">
                         The task creator, staff, and the tool's owner/backup owners
                     </label>
-                </div>
-                <div class="radio">
+                    <br>
                     <label>
                         <input type="radio"
                                name="tool_problem_update_permission"

--- a/NEMO/templates/customizations/customizations_tool.html
+++ b/NEMO/templates/customizations/customizations_tool.html
@@ -264,6 +264,41 @@
             </div>
         </div>
         <div class="form-group">
+            <label class="control-label col-sm-4 col-md-3">Who can add updates</label>
+            <div class="col-sm-8 col-md-9">
+                <div class="radio">
+                    <label>
+                        <input type="radio"
+                               name="tool_problem_update_permission"
+                               {% if tool_problem_update_permission == 'creator' %}checked{% endif %}
+                               value="creator">
+                        Only the task creator
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio"
+                               name="tool_problem_update_permission"
+                               {% if not tool_problem_update_permission or tool_problem_update_permission == 'staff' %}checked{% endif %}
+                               value="staff">
+                        The task creator, staff, and the tool's owner/backup owners
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio"
+                               name="tool_problem_update_permission"
+                               {% if tool_problem_update_permission == 'all' %}checked{% endif %}
+                               value="all">
+                        Any user
+                    </label>
+                </div>
+                <div class="help-block light-grey">
+                    Controls who can add a follow-up update to a pending tool problem (in addition to staff, who can already fully edit tasks from the maintenance page). Tool owners and superusers can always add updates, regardless of this setting.
+                </div>
+            </div>
+        </div>
+        <div class="form-group">
             <label class="control-label col-sm-4 col-md-3" for="tool_problem_max_image_size_pixels">Limit task images size</label>
             <div class="col-md-3">
                 <div class="input-group">

--- a/NEMO/templates/tool_control/tool_status.html
+++ b/NEMO/templates/tool_control/tool_status.html
@@ -320,6 +320,27 @@
                                         </div>
                                     </div>
                                 {% endif %}
+                                {% with update_permission=customizations|get_item:"tool_problem_update_permission" %}
+                                    {% if user.id == t.creator.id or user in tool.superusers.all or update_permission == "all" or update_permission == "staff" and user_qualifies_for_task_updates %}
+                                        <div class="media">
+                                            <span class="glyphicon glyphicon-plus-sign pull-left notification-icon success-highlight"></span>
+                                            <div class="media-body">
+                                                <a onclick="$(this).hide();$('#task_{{ t.id }}_add_info').show();" class="pointer">Add more information</a>
+                                                <div id="task_{{ t.id }}_add_info" style="display: none">
+                                                    <div class="input-group" style="width: 100%">
+                                                        <textarea id="task_{{ t.id }}_additional_info"
+                                                                  class="form-control"
+                                                                  oninput="auto_size_textarea(this);"
+                                                                  placeholder="Add more information about this problem. This will be appended to the progress updates above (cannot be used to edit what was already entered.)"></textarea>
+                                                        <span class="input-group-addon btn btn-success"
+                                                              style="color: #fff"
+                                                              onclick="add_task_information('{% url 'add_task_information' t.id %}', $('#task_{{ t.id }}_additional_info').val())">Add</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                {% endwith %}
                                 {% if t.task_images %}
                                     <div>
                                         images:
@@ -1210,6 +1231,16 @@
     </a>
 {% endif %}
 <script>
+	function add_task_information(url, description)
+	{
+		if (!description || !description.trim())
+		{
+			return;
+		}
+		let failure_dialog = ajax_failure_callback("Unable to add information to this task");
+		ajax_post(url, {'description': description}, refresh_tool_status, [failure_dialog]);
+	}
+
 	$(".contact-info-tooltip").on('click', function () {
         $(".tooltip").remove();
       	$(this).tooltip({trigger: 'manual', html: 'true', title: $(this).data('title')}).tooltip('toggle');

--- a/NEMO/urls.py
+++ b/NEMO/urls.py
@@ -325,6 +325,7 @@ urlpatterns += [
     path("create_task/", tasks.create, name="create_task"),
     path("cancel_task/<int:task_id>/", tasks.cancel, name="cancel_task"),
     path("update_task/<int:task_id>/", tasks.update, name="update_task"),
+    path("add_task_information/<int:task_id>/", tasks.add_task_information, name="add_task_information"),
     path("task_update_form/<int:task_id>/", tasks.task_update_form, name="task_update_form"),
     path("task_resolution_form/<int:task_id>/", tasks.task_resolution_form, name="task_resolution_form"),
     # Calendar:

--- a/NEMO/views/customization.py
+++ b/NEMO/views/customization.py
@@ -733,6 +733,7 @@ class ToolCustomization(CustomizationBase):
         "tool_problem_send_to_all_qualified_users": "",
         "tool_problem_allow_regular_user_preferences": "",
         "tool_problem_safety_hazard_automatic_shutdown": "",
+        "tool_problem_update_permission": "staff",
         "tool_configuration_setting_template": "{{ current_setting }}",
         "tool_configuration_near_future_days": "1",
         "tool_configuration_change_while_in_use": "",

--- a/NEMO/views/tasks.py
+++ b/NEMO/views/tasks.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.files.base import ContentFile
 from django.db.models import Q
-from django.http import HttpResponseBadRequest, HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import linebreaksbr
 from django.utils import timezone
@@ -333,6 +333,56 @@ def update(request, task_id):
         return redirect("maintenance")
     else:
         return redirect("tool_control")
+
+
+@login_required
+@require_POST
+def add_task_information(request, task_id):
+    """
+    Lets the user who created a task (depending on the "tool_problem_update_permission"
+    customization, staff or any user) append additional information to a pending task without going
+    through the full staff-only update flow. Tool superusers can always do this regardless of that
+    setting. This can only add to the description (using the same timestamped progress log staff updates
+    use); it cannot change urgency, category, force a shutdown, or modify anything else about the task,
+    and it cannot edit text that was already entered.
+    """
+    task = get_object_or_404(Task, id=task_id)
+    user: User = request.user
+    is_tool_superuser = user in task.tool.superusers.all()
+    permission = ToolCustomization.get("tool_problem_update_permission")
+    if permission == "all":
+        authorized = True
+    elif permission == "creator":
+        authorized = user == task.creator or is_tool_superuser or user.is_superuser
+    else:
+        authorized = (
+            user == task.creator
+            or user.is_staff_on_tool(task.tool)
+            or user == task.tool.primary_owner
+            or user in task.tool.backup_owners.all()
+            or is_tool_superuser
+            or user.is_superuser
+        )
+    if not authorized:
+        return HttpResponseBadRequest("You are not authorized to update this task.")
+    if task.cancelled or task.resolved:
+        return HttpResponseBadRequest("This task can no longer be updated because it has been cancelled or resolved.")
+    description = request.POST.get("description", "").strip()
+    if not description:
+        return HttpResponseBadRequest("Please enter some information to add to this task.")
+    now = timezone.now()
+    preface = f"On {format_datetime(now)} {user.get_full_name()} updated this task:\n"
+    if task.progress_description:
+        task.progress_description += "\n\n" + preface + description
+    else:
+        task.progress_description = preface + description
+    task.progress_description = task.progress_description.strip()
+    task.last_updated = now
+    task.last_updated_by = user
+    task.save()
+    determine_tool_status(task.tool)
+    send_task_updated_email(task, get_full_url(task.tool.get_absolute_url(), request))
+    return HttpResponse()
 
 
 @staff_member_or_tool_staff_required

--- a/NEMO/views/tool_control.py
+++ b/NEMO/views/tool_control.py
@@ -136,6 +136,12 @@ def tool_status(request, tool_id):
         or (user_is_qualified and broadcast_upcoming_reservation == "qualified")
         or broadcast_upcoming_reservation == "all",
         "tool_control_show_task_details": ToolControlCustomization.get_bool("tool_control_show_task_details"),
+        "user_qualifies_for_task_updates": (
+            user.is_staff_on_tool(tool)
+            or user.id == tool.primary_owner_id
+            or user in tool.backup_owners.all()
+            or user.is_superuser
+        ),
         "user_can_see_documents": user.is_any_part_of_staff
         or not ToolControlCustomization.get_bool("tool_control_show_documents_only_qualified_users")
         or user_is_qualified,


### PR DESCRIPTION
This PR allows regular users to add progress updates for the tasks they created in a non-destructive manner from the tool control page and resolves #190. There is also a new option to allow you to change who can add progress updates. Tool super users and sitewide superusers will always be allowed to edit notes, alongside the creator of the note itself. Staff may also append notes in the maintenance page already. By default, staff, the tool owner and backup owner, are allowed to add updates. Video demonstration below.

https://github.com/user-attachments/assets/2ddf35db-c5f0-444c-b204-adaa320ae7a2

Screenshot of the option in the customization page on the "Tools" tab:
 
<img width="1104" height="198" alt="image" src="https://github.com/user-attachments/assets/544260ac-a74e-46d5-99dc-f1ba0be9c8ea" />

Also, lab members have requested the ability to edit their own notes. I think this is a great addition, though we need to consider how note edits should trigger email notifications (or if it should at all?)