### PR TITLE
Able to add tool superusers/owners to modify tasks (resolves #226)

### DIFF
--- a/NEMO/models.py
+++ b/NEMO/models.py
@@ -4118,6 +4118,24 @@ class Task(BaseModel):
     def task_images(self):
         return TaskImages.objects.filter(task=self).order_by()
 
+    def can_be_managed_by(self, user: User) -> bool:
+        """
+        Whether the given user can update or resolve this task, beyond staff (who can always do so).
+        Controlled by the "tool_task_management_allow_owners" and "tool_task_management_allow_superusers"
+        customizations, which are both off by default.
+        """
+        from NEMO.views.customization import ToolCustomization
+
+        if user.is_staff_on_tool(self.tool):
+            return True
+        if ToolCustomization.get_bool("tool_task_management_allow_owners") and (
+            user == self.tool.primary_owner or user in self.tool.backup_owners.all()
+        ):
+            return True
+        if ToolCustomization.get_bool("tool_task_management_allow_superusers") and user in self.tool.superusers.all():
+            return True
+        return False
+
 
 class TaskImages(BaseModel):
     task = models.ForeignKey(Task, on_delete=models.CASCADE)

--- a/NEMO/templates/customizations/customizations_tool.html
+++ b/NEMO/templates/customizations/customizations_tool.html
@@ -264,6 +264,30 @@
             </div>
         </div>
         <div class="form-group">
+            <label class="control-label col-sm-4 col-md-3">Task permissions</label>
+            <div class="col-sm-8 col-md-9">
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox"
+                               name="tool_task_management_allow_owners"
+                               {% if tool_task_management_allow_owners %}checked{% endif %}
+                               value="enabled">
+                        Allow the tool's owner and backup owners to update or resolve tasks (in addition to staff)
+                    </label>
+                    <label>
+                        <input type="checkbox"
+                               name="tool_task_management_allow_superusers"
+                               {% if tool_task_management_allow_superusers %}checked{% endif %}
+                               value="enabled">
+                        Allow tool superusers to update or resolve tasks (in addition to staff)
+                    </label>
+                </div>
+                <div class="help-block light-grey">
+                    Whoever is allowed here can fully update or resolve a pending task from the tool control page.
+                </div>
+            </div>
+        </div>
+        <div class="form-group">
             <label class="control-label col-sm-4 col-md-3" for="tool_problem_max_image_size_pixels">Limit task images size</label>
             <div class="col-md-3">
                 <div class="input-group">

--- a/NEMO/templates/tool_control/past_tasks_and_comments.html
+++ b/NEMO/templates/tool_control/past_tasks_and_comments.html
@@ -27,7 +27,7 @@
                             The tool was shut down because of this task.
                             <br>
                         {% endif %}
-                        {% if user|is_staff_on_tool:tool %}
+                        {% if user|can_manage_task:i %}
                             You can <a href="{% url 'task_update_form' i.id %}">reopen</a> this task if it was mistakenly resolved.
                         {% endif %}
                     </span>

--- a/NEMO/templates/tool_control/tool_status.html
+++ b/NEMO/templates/tool_control/tool_status.html
@@ -299,7 +299,7 @@
                             <div id="task_{{ t.id }}_details" class="collapse{% if tool_control_show_task_details %} in{% endif %}">
                                 <span class="media-bottom">
                                     This task was created by {{ t.creator }} on {{ t.creation_time }}.
-                                    {% if user|is_staff_on_tool:tool %}
+                                    {% if user|can_manage_task:t %}
                                         You can <a href="{% url 'task_update_form' t.id %}">update</a> or <a href="{% url 'task_resolution_form' t.id %}">resolve</a> this task.
                                     {% endif %}
                                     {% if t.force_shutdown %}The tool will remain shut down until this task is resolved.{% endif %}

--- a/NEMO/templatetags/custom_tags_and_filters.py
+++ b/NEMO/templatetags/custom_tags_and_filters.py
@@ -332,6 +332,13 @@ def is_staff_on_tool(user: User, tool: Tool) -> bool:
             return user in tool.staff.all()
 
 
+@register.filter(name="can_manage_task")
+def can_manage_task(user: User, task) -> bool:
+    if not user or not task:
+        return False
+    return task.can_be_managed_by(user)
+
+
 @register.simple_tag
 def render_tool_properties(tool_properties):
     """

--- a/NEMO/views/customization.py
+++ b/NEMO/views/customization.py
@@ -733,6 +733,8 @@ class ToolCustomization(CustomizationBase):
         "tool_problem_send_to_all_qualified_users": "",
         "tool_problem_allow_regular_user_preferences": "",
         "tool_problem_safety_hazard_automatic_shutdown": "",
+        "tool_task_management_allow_owners": "",
+        "tool_task_management_allow_superusers": "",
         "tool_configuration_setting_template": "{{ current_setting }}",
         "tool_configuration_near_future_days": "1",
         "tool_configuration_change_while_in_use": "",

--- a/NEMO/views/tasks.py
+++ b/NEMO/views/tasks.py
@@ -11,7 +11,7 @@ from django.template.defaultfilters import linebreaksbr
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
 
-from NEMO.decorators import postpone, staff_member_or_tool_staff_required
+from NEMO.decorators import postpone
 from NEMO.forms import TaskForm, TaskImagesForm, nice_errors
 from NEMO.models import (
     Interlock,
@@ -305,12 +305,12 @@ Visit {url} to view the tool control page for the task.<br/>
         tasks_logger.exception(error_message)
 
 
-@staff_member_or_tool_staff_required
+@login_required
 @require_POST
 def update(request, task_id):
     task = get_object_or_404(Task, id=task_id)
     user: User = request.user
-    if not user.is_staff and task.tool_id not in user.staff_for_tools.values_list("id", flat=True):
+    if not task.can_be_managed_by(user):
         return HttpResponseBadRequest("You are not authorized to update this task.")
     images_form = TaskImagesForm(request.POST, request.FILES)
     form = TaskForm(request.user, data=request.POST, instance=task)
@@ -335,12 +335,12 @@ def update(request, task_id):
         return redirect("tool_control")
 
 
-@staff_member_or_tool_staff_required
+@login_required
 @require_GET
 def task_update_form(request, task_id):
     user: User = request.user
     task = get_object_or_404(Task, id=task_id)
-    if not user.is_staff and task.tool_id not in user.staff_for_tools.values_list("id", flat=True):
+    if not task.can_be_managed_by(user):
         return HttpResponseBadRequest("You are not authorized to update this task.")
     categories = TaskCategory.objects.filter(stage=TaskCategory.Stage.INITIAL_ASSESSMENT)
     dictionary = {
@@ -356,12 +356,12 @@ def task_update_form(request, task_id):
     return render(request, "tasks/update.html", dictionary)
 
 
-@staff_member_or_tool_staff_required
+@login_required
 @require_GET
 def task_resolution_form(request, task_id):
     user: User = request.user
     task = get_object_or_404(Task, id=task_id)
-    if not user.is_staff and task.tool_id not in user.staff_for_tools.values_list("id", flat=True):
+    if not task.can_be_managed_by(user):
         return HttpResponseBadRequest("You are not authorized to resolve this task.")
     categories = TaskCategory.objects.filter(stage=TaskCategory.Stage.COMPLETION)
     dictionary = {
@@ -378,8 +378,8 @@ def set_task_status(request, task, status_name, user):
     if not status_name:
         return
 
-    if not user.is_staff and not user.is_staff_on_tool(task.tool):
-        raise ValueError("Only staff can set task status")
+    if not task.can_be_managed_by(user):
+        raise ValueError("You are not authorized to set this task's status")
 
     status = TaskStatus.objects.get(name=status_name)
     TaskHistory.objects.create(task=task, status=status_name, user=user)


### PR DESCRIPTION
This PR adds a customization setting to allow the tool superusers or owners to update/resolve tasks in addition to staff, and resolves #226. The setting in customization is below:

<img width="1037" height="120" alt="image" src="https://github.com/user-attachments/assets/a162ef4c-7240-47fc-b6f9-ced44d87f843" />
