### PR TITLE
Additional reservation UX improvements on mobile

### DIFF
--- a/NEMO/templates/landing.html
+++ b/NEMO/templates/landing.html
@@ -2,6 +2,56 @@
 {% load static %}
 {% load custom_tags_and_filters %}
 {% block title %}{{ site_title }}{% endblock %}
+{% block extrahead %}
+    {% if upcoming_reservations %}
+        <script type="text/javascript">
+            function show_reservation_details(reservation_id)
+            {
+                let failure_dialog = ajax_failure_callback("Unable to display details");
+                let url = build_django_url("{% url 'reservation_details' 0 %}", [0], [reservation_id]);
+                ajax_get(url + '?popup_view=true', undefined, ajax_success_callback, [failure_dialog]);
+            }
+
+            function refresh_calendar_and_sidebar()
+            {
+                location.reload();
+            }
+
+            function cancel_reservation(url, reservation_id, reason)
+            {
+                let failure_dialog = ajax_failure_callback("Unable to cancel this reservation");
+                let contents = reason ? {'reason': reason} : undefined;
+                ajax_post(url, contents, refresh_calendar_and_sidebar, [failure_dialog, refresh_calendar_and_sidebar]);
+            }
+
+            function set_reservation_title(url, reservation_id, title)
+            {
+                let failure_dialog = ajax_failure_callback("Unable to set reservation title");
+                ajax_post(url, {'title': title}, refresh_calendar_and_sidebar, [failure_dialog, refresh_calendar_and_sidebar]);
+            }
+
+            function change_reservation_note(url, note)
+            {
+                let failure_dialog = ajax_failure_callback("Unable to change reservation note");
+                ajax_post(url, {'note': note}, refresh_calendar_and_sidebar, [failure_dialog, refresh_calendar_and_sidebar]);
+            }
+
+            function change_reservation_date(url, reservation_id, param, value)
+            {
+                let failure_dialog = ajax_failure_callback("Unable to change reservation date");
+                let data = {'id': reservation_id};
+                data[param] = value;
+                ajax_post(url, data, refresh_calendar_and_sidebar, [failure_dialog, refresh_calendar_and_sidebar]);
+            }
+
+            function change_reservation_project(url, project_id)
+            {
+                let failure_dialog = ajax_failure_callback("Unable to change reservation project");
+                ajax_post(url, {'project_id': project_id}, refresh_calendar_and_sidebar, [failure_dialog, refresh_calendar_and_sidebar]);
+            }
+        </script>
+    {% endif %}
+{% endblock %}
 {% block content %}
     <h1 class="sr-only">Main dashboard</h1>
     {% if user.training_required %}
@@ -20,33 +70,30 @@
                 <h3>Upcoming reservations</h3>
                 <div id="upcoming-reservations">
                     {% for r in upcoming_reservations %}
-                        {% if r.tool %}
-                            <a href="{% url 'tool_control' r.tool.id %}" style="text-decoration: none">
-                            {% elif self_log_in and r.area and r.start < now %}
-                                <a href="{% url 'self_log_in' %}?area_id={{ r.area.id }}" style="text-decoration: none">
-                                {% elif device == 'mobile' and r.area %}
-                                    <a href="{% url 'view_calendar' item_type='area' item_id=r.area.id date=r.start|date:'Y-m-d' %}"
-                                       style="text-decoration: none">
+                        {% if self_log_in and r.area and r.start < now %}
+                            <a href="{% url 'self_log_in' %}?area_id={{ r.area.id }}" style="text-decoration: none">
+                        {% else %}
+                            <a href="javascript:void(0)" onclick="show_reservation_details({{ r.id }})" style="text-decoration: none">
+                        {% endif %}
+                            <div class="alert {% if r.start < now %}alert-warning{% else %}alert-success{% endif %}">
+                                {% if r.title %}
+                                    <b>{{ r.title }}</b>
+                                    <br>
+                                {% endif %}
+                                <b>
+                                    {% if r.start < now %}
+                                        You're late for your {{ r.reservation_item }} reservation!
+                                    {% else %}
+                                        {{ r.reservation_item }}
                                     {% endif %}
-                                    <div class="alert {% if r.start < now %}alert-warning{% else %}alert-success{% endif %}">
-                                        {% if r.title %}
-                                            <b>{{ r.title }}</b>
-                                            <br>
-                                        {% endif %}
-                                        <b>
-                                            {% if r.start < now %}
-                                                You're late for your {{ r.reservation_item }} reservation!
-                                            {% else %}
-                                                {{ r.reservation_item }}
-                                            {% endif %}
-                                        </b>
-                                        <br>
-                                        Starting on {{ r.start }}
-                                        <br>
-                                        Ending on {{ r.end }}
-                                    </div>
-                                    {% if r.tool or device == 'mobile' and r.area or self_log_in and r.area and r.start < now %}</a>{% endif %}
-                            {% endfor %}
+                                </b>
+                                <br>
+                                Starting on {{ r.start }}
+                                <br>
+                                Ending on {{ r.end }}
+                            </div>
+                        </a>
+                    {% endfor %}
                         </div>
                     </div>
                 {% endif %}

--- a/NEMO/templates/mobile/new_reservation.html
+++ b/NEMO/templates/mobile/new_reservation.html
@@ -33,15 +33,17 @@
         {% endif %}
         <h4>When would you like to reserve the {{ item }}?</h4>
         <div class="form-group">
+            <label for="date">Start date</label>
             <input type="text"
                    id="date"
                    name="date"
                    class="form-control"
-                   aria-label="Reservation day"
-                   placeholder="Choose a date"
+                   aria-label="Reservation start date"
+                   placeholder="Choose a start date"
                    required>
         </div>
         <div class="form-group">
+            <label for="start">Start time</label>
             <input type="text"
                    id="start"
                    name="start"
@@ -50,7 +52,23 @@
                    placeholder="Choose a start time"
                    required>
         </div>
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" id="overnight_reservation">
+                Overnight reservation (end on a different day)
+            </label>
+        </div>
+        <div class="form-group" id="end_date_group" style="display:none">
+            <label for="end_date">End date</label>
+            <input type="text"
+                   id="end_date"
+                   name="end_date"
+                   class="form-control"
+                   aria-label="Reservation end date"
+                   placeholder="Choose an end date">
+        </div>
         <div class="form-group">
+            <label for="end">End time</label>
             <input type="text"
                    id="end"
                    name="end"
@@ -72,14 +90,42 @@
 		{% for times in item_reservation_times %}
 		unavailable_times.push([{{ times.start|date:"U" }},{{ times.end|date:"U" }}]);
 		{% endfor %}
-		let date_picker = $('#date').pickadate({format: "{{ pickadate_date_format }}", formatSubmit: "yyyy-mm-dd", firstDay: 1, hiddenName: true, onSet: refresh_times});
+		let end_date_manually_set = false;
+		let date_picker = $('#date').pickadate({format: "{{ pickadate_date_format }}", formatSubmit: "yyyy-mm-dd", firstDay: 1, hiddenName: true, onSet: function() { sync_end_date(); refresh_times(); }});
+		let end_date_picker = $('#end_date').pickadate({format: "{{ pickadate_date_format }}", formatSubmit: "yyyy-mm-dd", firstDay: 1, hiddenName: true, onSet: function(thing) { if (thing.select) { end_date_manually_set = true; } refresh_times(); }});
 		let start_time_picker = $('#start').pickatime({interval: {{ calendar_slot_duration }},  format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(true), onSet: function() { end_time_picker.pickatime('picker').render(); }});
 		let end_time_picker = $('#end').pickatime({interval: {{ calendar_slot_duration }}, format: "{{ pickadate_time_format }}", formatSubmit: "H:i", hiddenName: true, formatLabel: format_labels(false)});
 		// set initial date
 		if ('{{ date|default_if_none:'' }}')
 		{
-            date_picker.pickadate('picker').set('select', '{{ date|input_date_format }}', {format: '{{ pickadate_date_format }}'})
+            date_picker.pickadate('picker').set('select', '{{ date|input_date_format }}', {format: '{{ pickadate_date_format }}'});
+            end_date_picker.pickadate('picker').set('select', '{{ date|input_date_format }}', {format: '{{ pickadate_date_format }}'});
         }
+        function sync_end_date()
+        {
+            // Keep the end date lined up with the start date until the user deliberately picks a different one
+            // (i.e. for an overnight reservation).
+            if (!end_date_manually_set)
+            {
+                let selected = date_picker.pickadate('picker').get('select');
+                if (selected)
+                {
+                    end_date_picker.pickadate('picker').set('select', selected.pick, {muted: true});
+                }
+            }
+        }
+        $('#overnight_reservation').on('change', function () {
+            if (this.checked)
+            {
+                $('#end_date_group').show();
+            }
+            else
+            {
+                $('#end_date_group').hide();
+                end_date_manually_set = false;
+                sync_end_date();
+            }
+        });
 		function refresh_times()
         {
             start_time_picker.pickatime('picker').render();
@@ -89,9 +135,10 @@
         {
             return function format_label(time)
             {
-                if (date_picker.pickadate('picker').get('select') && unavailable_times.length > 0)
+                let relevant_date_picker = is_start ? date_picker : end_date_picker;
+                if (relevant_date_picker.pickadate('picker').get('select') && unavailable_times.length > 0)
                 {
-                    let date_selected = date_picker.pickadate('picker').get('select').pick; // selected date in milliseconds
+                    let date_selected = relevant_date_picker.pickadate('picker').get('select').pick; // selected date in milliseconds
                     let time_selected = time.pick * 60 * 1000; // time in milliseconds
                     let date_time_selected = (date_selected + time_selected)/1000; // back to seconds to compare with python timestamp
                     for (let i=0 ; i < unavailable_times.length; i++)
@@ -102,7 +149,8 @@
                         if (!is_start && date_time_selected === start)
                         {
                             let selected_start = start_time_picker.pickatime('picker').get('select');
-                            let start_time_selected = selected_start ? (date_selected + selected_start.pick * 60 * 1000) / 1000 : null;
+                            let start_date_selected = date_picker.pickadate('picker').get('select');
+                            let start_time_selected = selected_start && start_date_selected ? (start_date_selected.pick + selected_start.pick * 60 * 1000) / 1000 : null;
                             if (start_time_selected === null || date_time_selected > start_time_selected)
                             {
 {# djlint:off #}

--- a/NEMO/templates/mobile/reservation_extra.html
+++ b/NEMO/templates/mobile/reservation_extra.html
@@ -8,6 +8,7 @@
         {% csrf_token %}
         <input type="hidden" name="date" value="{{ request_date }}">
         <input type="hidden" name="start" value="{{ request_start }}">
+        <input type="hidden" name="end_date" value="{{ request_end_date }}">
         <input type="hidden" name="end" value="{{ request_end }}">
         <input type="hidden" name="item_id" value="{{ reservation.reservation_item.id }}">
         <input type="hidden" name="item_type" value="{{ reservation.reservation_item_type.value }}">

--- a/NEMO/templates/mobile/view_calendar.html
+++ b/NEMO/templates/mobile/view_calendar.html
@@ -1,6 +1,13 @@
 {% extends 'base.html' %}
+{% load static %}
 {% load custom_tags_and_filters %}
 {% block title %}{{ item }} calendar{% endblock %}
+{% block extrahead %}
+    <script type="text/javascript" src="{% static "pickadate/picker.js" %}"></script>
+    <script type="text/javascript" src="{% static "pickadate/picker.date.js" %}"></script>
+    <link rel="stylesheet" type="text/css" href="{% static "pickadate/default.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static "pickadate/default.date.css" %}" />
+{% endblock %}
 {% block content %}
     <div class="row" style="font-size:1.7em; margin-bottom:20px">
         <div class="col-xs-2">
@@ -10,9 +17,12 @@
             {{ item }}
             {% include 'snippets/item_status_icons.html' with icon_size='large' %}
             <br>
-            {{ current_day|date:"l" }}
-            <br>
-            {{ current_day|date:"F jS" }}
+            <a id="jump_to_date_link" href="javascript:void(0)" style="color:inherit; text-decoration:underline dotted; display:block">
+                {{ current_day|date:"l" }}
+                <br>
+                {{ current_day|date:"F jS" }}
+            </a>
+            <input type="text" id="jump_to_date" style="position:absolute; opacity:0; height:0; width:0; padding:0; border:0" aria-label="Jump to date">
         </div>
         <div class="col-xs-2">
             <a href="{% url 'view_calendar' item_type item.id %}{{ next_day|date:"Y-m-d" }}/"><span class="glyphicon glyphicon-chevron-right"></span></a>
@@ -44,4 +54,26 @@
             </svg>
         </a>
     {% endif %}
+    <script>
+        window.addEventListener('load', function () {
+            let jump_to_date_picker = $('#jump_to_date').pickadate({
+                format: "{{ pickadate_date_format }}",
+                formatSubmit: "yyyy-mm-dd",
+                firstDay: 1,
+                container: 'body',
+                onSet: function (thing) {
+                    if (thing.select) {
+                        let picker = jump_to_date_picker.pickadate('picker');
+                        let selected_date = picker.get('select', 'yyyy-mm-dd');
+                        window.location.href = "{% url 'view_calendar' item_type item.id %}" + selected_date + "/";
+                    }
+                }
+            });
+            jump_to_date_picker.pickadate('picker').set('select', '{{ current_day.date|input_date_format }}', {format: '{{ pickadate_date_format }}', muted: true});
+            $('#jump_to_date_link').on('click', function (e) {
+                e.stopPropagation();
+                jump_to_date_picker.pickadate('picker').open();
+            });
+        });
+    </script>
 {% endblock %}

--- a/NEMO/views/mobile.py
+++ b/NEMO/views/mobile.py
@@ -85,8 +85,9 @@ def make_reservation(request):
     user: User = request.user
     try:
         date = parse_date(request.POST["date"])
+        end_date = parse_date(request.POST["end_date"]) if request.POST.get("end_date") else date
         start = localize(datetime.combine(date, parse_time(request.POST["start"])))
-        end = localize(datetime.combine(date, parse_time(request.POST["end"])))
+        end = localize(datetime.combine(end_date, parse_time(request.POST["end"])))
     except:
         return render(
             request,
@@ -135,6 +136,7 @@ def make_reservation(request):
         dictionary = {
             "request_date": request.POST["date"],
             "request_start": request.POST["start"],
+            "request_end_date": request.POST.get("end_date") or request.POST["date"],
             "request_end": request.POST["end"],
             "reservation": reservation,
         }


### PR DESCRIPTION
This PR introduces three new changes to how reservations can be created on mobile to make things more user-friendly and accessible, incorporating feedback from members in the lab using NEMO.

- Adds a date picker to the mobile calendar by pressing on the date label, so you do not have to navigate using only the arrows.
- Adds the ability to do overnight reservations by optionally setting the end date alongside the end time in the mobile UI.
- Clicking on a reservation notification on the landing page will now show a popup to modify and view your reservation details, allowing you to quickly cancel or modify without having to go to the calendar, instead of redirecting to the tool's control page.

A video demonstration is attached below.

https://github.com/user-attachments/assets/31b876f9-88e4-4456-b85f-c408a9fd90a0

