### PR TITLE
Staff maintenance ticket improvements (resolves #245)

### DIFF
--- a/NEMO/templates/maintenance/maintenance.html
+++ b/NEMO/templates/maintenance/maintenance.html
@@ -10,6 +10,12 @@
 {% block body %}
     <div class="container-fluid">
         <h1 class="pull-left" style="margin-right:20px; margin-top:0; margin-bottom:0">Maintenance</h1>
+        <button type="button"
+                class="btn btn-primary pull-right"
+                data-toggle="modal"
+                data-target="#report_problem_modal">
+            <span class="glyphicon glyphicon-plus"></span> Report a problem
+        </button>
         <ul class="nav nav-pills" id="tabs">
             <li class="{% if not tab or tab == 'pending' %}active{% endif %}">
                 <a href="#pending">Pending</a>
@@ -136,6 +142,79 @@
             <div id="closed_task_details" class="split-screen-right-panel"></div>
         </div>
     </div>
+    <div class="modal fade" id="report_problem_modal" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <form action="{% url 'create_task' %}"
+                      method="post"
+                      enctype="multipart/form-data"
+                      id="report_problem_form">
+                    {% csrf_token %}
+                    <input type="hidden" name="action" value="create">
+                    <input type="hidden" name="next_page" value="maintenance">
+                    <input type="hidden" id="report_problem_tool_id" name="tool">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        <h4 class="modal-title">Report a problem</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>
+                            Search for any tool below, including tools that are hidden from regular users, to report a problem or create a task for it.
+                        </p>
+                        <div class="form-group">
+                            <label for="report_problem_tool_search">Tool</label>
+                            <input id="report_problem_tool_search"
+                                   class="form-control"
+                                   placeholder="Search for a tool"
+                                   autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label for="report_problem_urgency">Urgency</label>
+                            <select id="report_problem_urgency" name="urgency" class="form-control">
+                                {% for level in urgency %}<option value="{{ level.0 }}">{{ level.1 }}</option>{% endfor %}
+                            </select>
+                        </div>
+                        {% if task_categories %}
+                            <div class="form-group">
+                                <label for="report_problem_category">Problem category</label>
+                                <select id="report_problem_category" name="problem_category" class="form-control">
+                                    <option value="">&nbsp;</option>
+                                    {% for c in task_categories %}<option value="{{ c.id }}">{{ c.name }}</option>{% endfor %}
+                                </select>
+                            </div>
+                        {% endif %}
+                        <div class="form-group">
+                            <label for="report_problem_description">Description</label>
+                            <textarea id="report_problem_description"
+                                      name="description"
+                                      class="form-control"
+                                      rows="5"
+                                      required></textarea>
+                        </div>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="safety_hazard"> This problem is a safety hazard
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="force_shutdown"> Shut down the tool until this problem is resolved
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <input aria-label="File upload" type="file" name="image" multiple>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        {% button type="delete" submit=True icon="glyphicon-send" value="Report problem" %}
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
     <script>
 	function pending_task_details(row, url)
 	{
@@ -208,6 +287,21 @@
         window.location.href = this_url.toString();
     }
 
+    function select_report_problem_tool(jquery_event, search_selection)
+    {
+        $('#report_problem_tool_search').typeahead('val', search_selection.name);
+        $('#report_problem_tool_id').val(search_selection.id);
+    }
+
+    function on_report_problem_submit(event)
+    {
+        if (!$('#report_problem_tool_id').val())
+        {
+            event.preventDefault();
+            alert('Please select a tool from the list before reporting a problem.');
+        }
+    }
+
 	function on_load()
 	{
 		$("#tabs a").click(switch_tab);
@@ -225,6 +319,13 @@
             {
                 filter_tool_category('', {'name': ''});
             }
+        });
+        $('#report_problem_tool_search').autocomplete('tools', select_report_problem_tool, {{ reportable_tools|json_search_base }});
+        $('#report_problem_form').on('submit', on_report_problem_submit);
+        $('#report_problem_modal').on('hidden.bs.modal', function ()
+        {
+            $('#report_problem_form')[0].reset();
+            $('#report_problem_tool_id').val('');
         });
 
 	}

--- a/NEMO/views/maintenance.py
+++ b/NEMO/views/maintenance.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_GET
 
 from NEMO.decorators import staff_member_or_tool_staff_required
-from NEMO.models import Task, TaskCategory, TaskStatus, User
+from NEMO.models import Task, TaskCategory, TaskStatus, Tool, User
 from NEMO.utilities import as_timezone, get_tool_categories_for_filters
 
 
@@ -60,12 +60,17 @@ def maintenance(request, sort_by=""):
             Q(tool___category=tool_category) | (Q(tool___category__startswith=tool_category + "/"))
         )
     closed_tasks = closed_tasks[:20]
+    # Tools staff can report a problem for from this page, including invisible ones (resolves #245)
+    reportable_tools = Tool.objects.all() if user.is_staff else user.staff_for_tools.all()
     dictionary = {
         "pending_tasks": pending_tasks,
         "closed_tasks": closed_tasks,
         "tool_categories": get_tool_categories_for_filters(),
         "tool_category": tool_category,
         "tab": request.GET.get("tab", "pending"),
+        "reportable_tools": reportable_tools,
+        "urgency": Task.Urgency.Choices,
+        "task_categories": TaskCategory.objects.filter(stage=TaskCategory.Stage.INITIAL_ASSESSMENT),
     }
     return render(request, "maintenance/maintenance.html", dictionary)
 

--- a/NEMO/views/tool_control.py
+++ b/NEMO/views/tool_control.py
@@ -77,7 +77,11 @@ def tool_control(request, item_type="tool", tool_id=None):
     # The tool-choice sidebar is not available for mobile devices, so redirect the user to choose a tool to view.
     if request.device == "mobile" and tool_id is None:
         return redirect("choose_item", next_page="tool_control")
-    tools = Tool.objects.filter(visible=True).order_by("_category", "name")
+    tools_filter = Q(visible=True)
+    if tool_id and user.is_any_part_of_staff:
+        # Allow staff to access a specific invisible tool directly via its hard link 
+        tools_filter |= Q(id=tool_id)
+    tools = Tool.objects.filter(tools_filter).order_by("_category", "name")
     dictionary = {"tools": tools, "selected_tool": tool_id}
     # The tool-choice sidebar only needs to be rendered for desktop devices, not mobile devices.
     if request.device == "desktop":
@@ -92,9 +96,11 @@ def tool_status(request, tool_id):
     from NEMO.rates import rate_class
 
     user: User = request.user
-    tool = get_object_or_404_from_queryset(
-        Tool.objects.filter(id=tool_id, visible=True).prefetch_related("qualification_set__user")
-    )
+    tool_queryset = Tool.objects.filter(id=tool_id)
+    if not user.is_any_part_of_staff:
+        # Staff can access an invisible tool's status directly via its hard link (resolves #245)
+        tool_queryset = tool_queryset.filter(visible=True)
+    tool = get_object_or_404_from_queryset(tool_queryset.prefetch_related("qualification_set__user"))
     current_usage_event = tool.get_current_usage_event()
     user_is_qualified = tool.user_set.filter(id=user.id).exists()
     broadcast_upcoming_reservation = ToolControlCustomization.get("tool_control_broadcast_upcoming_reservation")


### PR DESCRIPTION
This is a small PR that resolves #245 by implementing two minor new changes:
1. Any NEMO staff can access and search for hidden tools from the tool control page to create tickets on.
2. From the maintenance page, you can now create tickets for a ticket manually. 

Here is a sample video demonstration with a hidden tool named Travis that isn't publicly accessible. Accessing it from its hard link also works.

https://github.com/user-attachments/assets/dafa7bda-7528-40a6-b0bf-a5f5d07a1e69

Two notes:
- It is not searchable in the tool control page unless you are on the hidden tool page itself, thereby keeping it accessible only by its hard link if you knew the tool ID. This can be changed if requested. 
- If #325 is merged, another field should be added in the form on the maintenace  template to account for the title field. 