### PR TITLE
Status dashboard problem details (resolves #192)

### DIFF
--- a/NEMO/templates/customizations/customizations_dashboard.html
+++ b/NEMO/templates/customizations/customizations_dashboard.html
@@ -74,6 +74,33 @@
                 </div>
             </div>
         </div>
+        <div class="form-group">
+            <label class="control-label col-md-3">Problem details</label>
+            <div class="col-md-9">
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox"
+                               id="dashboard_display_problem_details_enabled"
+                               name="dashboard_display_problem_details_enabled"
+                               {% if dashboard_display_problem_details_enabled %}checked{% endif %}
+                               value="enabled">
+                        Allow expanding a problematic tool to see its problem report details
+                    </label>
+                    <div class="help-block light-grey" style="margin-bottom:0;">
+                        Shows description, category, urgency, and estimated resolution time. Staff and admins can see this by default once enabled.
+                    </div>
+                </div>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox"
+                               name="dashboard_display_problem_details_visible_to_all"
+                               {% if dashboard_display_problem_details_visible_to_all %}checked{% endif %}
+                               value="enabled">
+                        Show problem report details to all users
+                    </label>
+                </div>
+            </div>
+        </div>
         <div class="form-group" style="margin-bottom: 0; border-top: dotted 1px #ddd">
             <div class="col-md-5">
                 <h5>Staff status</h5>

--- a/NEMO/templates/status_dashboard/tools.html
+++ b/NEMO/templates/status_dashboard/tools.html
@@ -1,3 +1,4 @@
+{% load humanize %}
 {% load custom_tags_and_filters %}
 <p>
     Staff members are highlighted in <span class="bg-success">&nbsp;green&nbsp;</span>
@@ -5,6 +6,16 @@
     Service personnel are highlighted in <span class="bg-warning">&nbsp;orange&nbsp;</span>
     <br>
 </p>
+{% if dashboard_display_problem_details %}
+    <p>
+        <button type="button" id="expand_all_problem_details" class="btn btn-default btn-xs">
+            <span class="glyphicon glyphicon-resize-full"></span> Expand all problem reports
+        </button>
+        <button type="button" id="collapse_all_problem_details" class="btn btn-default btn-xs">
+            <span class="glyphicon glyphicon-resize-small"></span> Collapse all problem reports
+        </button>
+    </p>
+{% endif %}
 <table class="table table-bordered table-condensed">
     <thead>
         <tr>
@@ -17,6 +28,14 @@
         {% for tool in tool_summary %}
             <tr class="{% if tool.operator_is_any_part_of_staff %}success {% elif tool.operator_is_service_personnel %}warning {% endif %}{% if tool.problematic or not tool.operational or tool.required_resource_is_unavailable or tool.nonrequired_resource_is_unavailable %}problematic{% else %}healthy{% endif %} {% if tool.in_use %}in_use{% else %}idle{% endif %}">
                 <td>
+                    {% if dashboard_display_problem_details and tool.problematic and tool.tasks %}
+                        <a href="javascript:void(0)"
+                           class="pointer toggle-problem-details"
+                           data-tool-id="{{ tool.id }}"
+                           title="Show/hide problem report details">
+                            <span class="glyphicon glyphicon-chevron-right"></span>
+                        </a>
+                    {% endif %}
                     {{ tool.get_tool_info_html|safe }}
                     {# Output the state of the tool, summarizing any associated problems. #}
                     {% if tool.in_use %}
@@ -65,6 +84,40 @@
                     <td aria-label="Not in use"></td>
                 {% endif %}
             </tr>
+            {% if dashboard_display_problem_details and tool.problematic and tool.tasks %}
+                <tr id="problem_details_{{ tool.id }}"
+                    data-tool-id="{{ tool.id }}"
+                    class="problem-details-row {% if tool.operator_is_any_part_of_staff %}success {% elif tool.operator_is_service_personnel %}warning {% endif %}problematic {% if tool.in_use %}in_use{% else %}idle{% endif %}"
+                    style="display:none">
+                    <td colspan="3" style="padding:10px">
+                        {% for task in tool.tasks %}
+                            <div{% if not forloop.last %} style="margin-bottom:10px; padding-bottom:10px; border-bottom:dotted 1px #ddd"{% endif %}>
+                                <strong>
+                                    {{ task.urgency }} urgency{% if task.problem_category %} &ndash; {{ task.problem_category }}{% endif %}
+                                </strong>
+                                {% if task.force_shutdown %}
+                                    <span class="glyphicon glyphicon-fire danger-highlight" title="This tool is shut down until this problem is resolved"></span>
+                                {% endif %}
+                                {% if task.safety_hazard %}
+                                    <span class="glyphicon glyphicon-exclamation-sign danger-highlight" title="This problem is a safety hazard"></span>
+                                {% endif %}
+                                <br>
+                                {{ task.description|linebreaksbr }}
+                                {% if task.progress_description %}
+                                    <br>
+                                    <em>Progress: {{ task.progress_description|linebreaksbr }}</em>
+                                {% endif %}
+                                {% if task.estimated_resolution_time %}
+                                    <br>
+                                    <span class="light-grey">Estimated resolution: {{ task.estimated_resolution_time }}</span>
+                                {% endif %}
+                                <br>
+                                <span class="light-grey">Reported {{ task.creation_time|naturaltime }}</span>
+                            </div>
+                        {% endfor %}
+                    </td>
+                </tr>
+            {% endif %}
         {% endfor %}
     </tbody>
 </table>
@@ -86,4 +139,67 @@
         }
     });
     $("[data-toggle='tooltip']").tooltip({html: 'true'});
+
+    // The tools tab is reloaded wholesale every few seconds by refresh_status_dashboard(), which would otherwise
+    // reset every problem-details row back to collapsed. Persist which tool ids are expanded in localStorage,
+    // and re-apply that state below every time this partial is (re)loaded.
+    function get_expanded_problem_details_tools()
+    {
+        try { return JSON.parse(localStorage['problemDetailsExpandedTools'] || '[]'); }
+        catch (e) { return []; }
+    }
+
+    function save_expanded_problem_details_tools(tool_ids)
+    {
+        localStorage['problemDetailsExpandedTools'] = JSON.stringify(tool_ids);
+    }
+
+    function set_problem_details_row_expanded(tool_id, expanded)
+    {
+        $("#problem_details_" + tool_id).toggle(expanded);
+        $(".toggle-problem-details[data-tool-id='" + tool_id + "'] .glyphicon")
+            .toggleClass('glyphicon-chevron-down', expanded)
+            .toggleClass('glyphicon-chevron-right', !expanded);
+    }
+
+    $(".toggle-problem-details").on('click', function ()
+    {
+        let tool_id = String($(this).data('tool-id'));
+        let expanded_tools = get_expanded_problem_details_tools();
+        let now_expanded = expanded_tools.indexOf(tool_id) === -1;
+        set_problem_details_row_expanded(tool_id, now_expanded);
+        if (now_expanded)
+        {
+            expanded_tools.push(tool_id);
+        }
+        else
+        {
+            expanded_tools = expanded_tools.filter(function (id) { return id !== tool_id; });
+        }
+        save_expanded_problem_details_tools(expanded_tools);
+    });
+    $("#expand_all_problem_details").on('click', function ()
+    {
+        let all_tool_ids = $(".problem-details-row").map(function () { return String($(this).data('tool-id')); }).get();
+        all_tool_ids.forEach(function (tool_id) { set_problem_details_row_expanded(tool_id, true); });
+        save_expanded_problem_details_tools(all_tool_ids);
+    });
+    $("#collapse_all_problem_details").on('click', function ()
+    {
+        $(".problem-details-row").each(function () { set_problem_details_row_expanded($(this).data('tool-id'), false); });
+        save_expanded_problem_details_tools([]);
+    });
+    // Re-apply whatever was expanded before this (re)load
+    (function ()
+    {
+        let expanded_tools = get_expanded_problem_details_tools();
+        $(".problem-details-row").each(function ()
+        {
+            let tool_id = String($(this).data('tool-id'));
+            if (expanded_tools.indexOf(tool_id) !== -1)
+            {
+                set_problem_details_row_expanded(tool_id, true);
+            }
+        });
+    })();
 </script>

--- a/NEMO/views/customization.py
+++ b/NEMO/views/customization.py
@@ -537,6 +537,8 @@ class StatusDashboardCustomization(CustomizationBase):
         "dashboard_staff_status_absence_view_user_office": "",
         "dashboard_staff_status_absence_view_accounting_officer": "",
         "dashboard_tool_sort": "name",
+        "dashboard_display_problem_details_enabled": "enabled",
+        "dashboard_display_problem_details_visible_to_all": "",
     }
 
 

--- a/NEMO/views/status_dashboard.py
+++ b/NEMO/views/status_dashboard.py
@@ -82,7 +82,21 @@ def status_dashboard(request, tab=None):
 
 def get_tools_dictionary(request):
     tool_categories = request.GET.getlist("category", [])
-    return {"tool_summary": create_tool_summary(tooltip_info=True, tool_categories=tool_categories)}
+    problem_details_enabled = StatusDashboardCustomization.get_bool("dashboard_display_problem_details_enabled")
+    problem_details_visible_to_all = StatusDashboardCustomization.get_bool(
+        "dashboard_display_problem_details_visible_to_all"
+    )
+    # Staff and admins can see problem details by default once the feature is enabled;
+    # everyone else needs the "visible to all" option turned on too.
+    include_problem_details = problem_details_enabled and (
+        request.user.is_any_part_of_staff or problem_details_visible_to_all
+    )
+    return {
+        "tool_summary": create_tool_summary(
+            tooltip_info=True, tool_categories=tool_categories, include_problem_details=include_problem_details
+        ),
+        "dashboard_display_problem_details": include_problem_details,
+    }
 
 
 def get_occupancy_dictionary(request):
@@ -353,7 +367,7 @@ def area_tree_helper(
     yield "out"
 
 
-def create_tool_summary(tooltip_info=False, tool_categories=None):
+def create_tool_summary(tooltip_info=False, tool_categories=None, include_problem_details=False):
     category_filter = Q()
     if tool_categories:
         for category in tool_categories:
@@ -369,6 +383,8 @@ def create_tool_summary(tooltip_info=False, tool_categories=None):
         )
     )
     tasks = Task.objects.filter(cancelled=False, resolved=False, tool__visible=True, tool__in=tools)
+    if include_problem_details:
+        tasks = tasks.select_related("tool", "problem_category")
     unavailable_resources = Resource.objects.filter(available=False).prefetch_related(
         "fully_dependent_tools", "partially_dependent_tools"
     )
@@ -381,7 +397,9 @@ def create_tool_summary(tooltip_info=False, tool_categories=None):
     scheduled_outages = ScheduledOutage.objects.filter(
         start__lte=timezone.now(), end__gt=timezone.now(), area__isnull=True
     ).prefetch_related("tool", "resource__fully_dependent_tools", "resource__partially_dependent_tools")
-    tool_summary = merge(tools, tasks, unavailable_resources, usage_events, scheduled_outages, tooltip_info)
+    tool_summary = merge(
+        tools, tasks, unavailable_resources, usage_events, scheduled_outages, tooltip_info, include_problem_details
+    )
     tool_summary = list(tool_summary.values())
     tool_sort = StatusDashboardCustomization.get("dashboard_tool_sort")
     max_date_aware = datetime.max.replace(tzinfo=timezone.get_default_timezone())
@@ -493,7 +511,7 @@ def create_area_summary(area_tree: ModelTreeHelper = None, add_resources=True, a
     return area_summary
 
 
-def merge(tools, tasks, unavailable_resources, usage_events, scheduled_outages, tooltip_info=False):
+def merge(tools, tasks, unavailable_resources, usage_events, scheduled_outages, tooltip_info=False, include_problem_details=False):
     result = {}
     tools_with_delayed_logoff_in_effect = [
         x.tool.tool_or_parent_id() for x in UsageEvent.objects.filter(end__gt=timezone.now()).prefetch_related("tool")
@@ -521,8 +539,28 @@ def merge(tools, tasks, unavailable_resources, usage_events, scheduled_outages, 
         }
         if tooltip_info:
             result[tool.tool_or_parent_id()]["get_tool_info_html"] = tool.get_tool_info_html()
-    for tool_id in tasks.values_list("tool_id", flat=True):
-        result[tool_id]["problematic"] = True
+        if include_problem_details:
+            result[tool.tool_or_parent_id()]["tasks"] = []
+    if include_problem_details:
+        for task in tasks:
+            tool_key = task.tool.tool_or_parent_id()
+            if tool_key in result:
+                result[tool_key]["problematic"] = True
+                result[tool_key]["tasks"].append(
+                    {
+                        "urgency": task.get_urgency_display(),
+                        "problem_category": task.problem_category.name if task.problem_category else None,
+                        "description": task.problem_description,
+                        "progress_description": task.progress_description,
+                        "force_shutdown": task.force_shutdown,
+                        "safety_hazard": task.safety_hazard,
+                        "estimated_resolution_time": task.estimated_resolution_time,
+                        "creation_time": task.creation_time,
+                    }
+                )
+    else:
+        for tool_id in tasks.values_list("tool_id", flat=True):
+            result[tool_id]["problematic"] = True
     for event in usage_events:
         result[event.tool.tool_or_parent_id()]["operator"] = str(event.operator)
         result[event.tool.tool_or_parent_id()]["user"] = str(event.operator)


### PR DESCRIPTION
This PR resolves #192 by introducing the ability to view existing tasks for each tool at a glance from the status dashboard, and buttons to quickly expand/collapse the tool details. Since there is an autorefresh the browser saves a list of expanded tools to localStorage for it to preserve state. 

By default, this is customized to be enabled, with all users not being able to see tasks by default in the status dashboard (staff/superusers only.) 

<img width="1000" height="150" alt="Screenshot From 2026-09-06 19-19-45" src="https://github.com/user-attachments/assets/2c05e889-75c6-42cc-b5ca-9d6f83dca3d0" />

Video demonstration below of this in action on the status dashboard.

https://github.com/user-attachments/assets/893365e9-b96d-475e-b791-55ef8f6475fc

Note that if #325 is implemented, this should be updated to also include the title of tasks to be shown alongside everything else . 