### PR TITLE
Email customization enhancements (resolves #290)

### DIFF
--- a/NEMO/migrations/0158_backfill_email_subject_customizations.py
+++ b/NEMO/migrations/0158_backfill_email_subject_customizations.py
@@ -1,0 +1,117 @@
+from django.db import migrations
+
+# Maps each email template name to a Django template string reproducing, as closely as possible, what the
+# hardcoded Python code currently computes as that email's subject line. Written once as real starting values
+# instead of the implicit "{{ default_subject }}" passthrough, so an admin visiting the customization page sees
+# the actual current subject (with its variables and branching spelled out) rather than an opaque placeholder.
+#
+# "generic_email" (the broadcast email) is intentionally excluded. Its subject is typed fresh by the sender on
+# every send, so there is no fixed "current default" to backfill.
+#
+# From/cc are intentionally left untouched everywhere, as none of these 28 templates branch on from/cc, so a
+# backfilled value there would be identical to the passthrough default already in effect.
+SUBJECT_TEMPLATES = {
+    "unauthorized_tool_access_email": (
+        '{% if type == "area-access" %}Area access requirement{% else %}Area reservation requirement{% endif %}'
+    ),
+    "access_request_notification_email": (
+        '{% if status == "received" or status == "updated" %}'
+        "Access request for the {{ access_request.physical_access_level.area }} {{ status }}"
+        "{% else %}"
+        "Your access request for the {{ access_request.physical_access_level.area }} has been {{ status }}"
+        "{% endif %}"
+    ),
+    "adjustment_request_notification_email": (
+        '{% if status == "received" or status == "updated" %}'
+        "Adjustment request {{ status }}"
+        "{% elif user_office %}"
+        "{{ adjustment_request.creator.get_name }}'s adjustment request has been {{ status }}"
+        "{% else %}"
+        "Your adjustment request has been {{ status }}"
+        "{% endif %}"
+    ),
+    "cancellation_email": "Your reservation was cancelled",
+    "counter_threshold_reached_email": "Warning threshold reached for {{ counter.tool.name }} {{ counter.name }} counter",
+    "facility_rules_tutorial_email": "{{ facility_name }} rules tutorial",
+    "feedback_email": "Feedback from {{ user }}",
+    "missed_reservation_email": "Missed reservation for the {{ reservation.reservation_item }}",
+    "new_task_email": (
+        "{% if task.safety_hazard %}SAFETY HAZARD: {% endif %}"
+        "{{ task.tool.name }}"
+        "{% if task.force_shutdown %} shutdown{% else %} problem{% endif %}"
+    ),
+    "out_of_time_reservation_email": (
+        "{% if reservation.start %}"
+        "Out of time for the {{ reservation.reservation_item }}"
+        "{% else %}"
+        "Out of allowed schedule for the {{ reservation.reservation_item }}"
+        "{% endif %}"
+    ),
+    "recurring_charges_reminder_email": "{{ recurring_charges_name }} will be charged in {{ reminder_days }} day(s)",
+    "reorder_supplies_reminder_email": "Time to order more {{ item.name }}",
+    "reservation_ending_reminder_email": "{{ reservation.reservation_item.name }} reservation ending soon",
+    "reservation_reminder_email": "{{ reservation.reservation_item.name }} reservation reminder",
+    "reservation_warning_email": (
+        "{{ reservation.reservation_item.name }} reservation {% if fatal_error %}problem{% else %}warning{% endif %}"
+    ),
+    "safety_issue_email": "Safety issue",
+    "scheduled_outage_reminder_email": "{{ outage.title }} reminder",
+    "staff_charge_reminder_email": 'Active staff charge since {{ staff_charge.start|date:"DATETIME_FORMAT" }}',
+    "task_status_notification": "{{ task.tool }} task notification",
+    "tool_qualification_expiration_email": (
+        "Your {{ tool.name }} qualification "
+        "{% if remaining_days %} expires in {{ remaining_days }} days!{% else %} has expired{% endif %}"
+    ),
+    "tool_required_unanswered_questions_email": (
+        "Unanswered post‑usage questions after logoff from the {{ tool.name }}"
+    ),
+    "usage_reminder_email": "{{ facility_name }} usage",
+    "user_access_expiration_reminder_email": (
+        "Your {{ facility_name }} access expires in {{ remaining_days }} days "
+        '({{ user.access_expiration|date:"DATE_FORMAT" }})'
+    ),
+    "reservation_created_user_email": "Reservation for the {{ reservation.reservation_item }}",
+    "reservation_cancelled_user_email": "Cancelled Reservation for the {{ reservation.reservation_item }}",
+    "weekend_access_email": (
+        "{% if not weekend_access %}NO w{% else %}W{% endif %}eekend access for the "
+        "{{ facility_name }} {{ sat }} - {{ sun }}"
+    ),
+    "wait_list_notification_email": "Your turn for the {{ tool }}",
+}
+
+
+def backfill_email_subjects(apps, schema_editor):
+    # Only skip a row if it holds a value other than the plain "{{ default_subject }}" passthrough: a row
+    # that's missing entirely, or one that's present but still exactly the passthrough placeholder, both mean
+    # "not really customized" (the passthrough placeholder was, until this migration, the only value the
+    # customization page's field could ever show, and can end up saved as a real row if the shared form was
+    # ever submitted without editing that field) - safe to fill in with the real subject in both cases. Any
+    # other existing value is a genuine admin customization and must be left alone.
+    Customization = apps.get_model("NEMO", "Customization")
+    for template_name, subject_template in SUBJECT_TEMPLATES.items():
+        name = f"{template_name}_subject"
+        existing = Customization.objects.filter(name=name).first()
+        if existing is None:
+            Customization.objects.create(name=name, value=subject_template)
+        elif existing.value == "{{ default_subject }}":
+            existing.value = subject_template
+            existing.save(update_fields=["value"])
+
+
+def remove_backfilled_email_subjects(apps, schema_editor):
+    # Only remove rows that still hold exactly the value this migration wrote - if an admin has since edited
+    # one of these fields to something else, that's their real customization and reversing must not delete it.
+    Customization = apps.get_model("NEMO", "Customization")
+    for template_name, subject_template in SUBJECT_TEMPLATES.items():
+        Customization.objects.filter(name=f"{template_name}_subject", value=subject_template).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("NEMO", "0157_task_assigned_to"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_email_subjects, remove_backfilled_email_subjects),
+    ]

--- a/NEMO/policy.py
+++ b/NEMO/policy.py
@@ -58,6 +58,7 @@ from NEMO.views.customization import (
     EmailsCustomization,
     ToolCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 
 policy_logger = getLogger(__name__)
@@ -210,13 +211,22 @@ class DefaultNEMOPolicy(BaseNEMOPolicy):
                 abuse_email_address = EmailsCustomization.get("abuse_email_address")
                 message = get_media_file_contents("unauthorized_tool_access_email.html")
                 if abuse_email_address and message:
-                    dictionary = {"operator": operator, "tool": tool, "type": "area-access"}
+                    dictionary = {
+                        "operator": operator,
+                        "tool": tool,
+                        "type": "area-access",
+                        "default_subject": "Area access requirement",
+                        "default_from_email": abuse_email_address,
+                        "default_cc_emails": "",
+                    }
                     rendered_message = render_email_template(message, dictionary)
+                    subject, from_email, cc = resolve_email_customization("unauthorized_tool_access_email", dictionary)
                     send_mail(
-                        subject="Area access requirement",
+                        subject=subject,
                         content=rendered_message,
-                        from_email=abuse_email_address,
+                        from_email=from_email,
                         to=[abuse_email_address],
+                        cc=cc,
                         email_category=EmailCategory.ABUSE,
                     )
                 return HttpResponseBadRequest(
@@ -247,13 +257,18 @@ class DefaultNEMOPolicy(BaseNEMOPolicy):
                         "operator": operator,
                         "tool": tool,
                         "type": "area-reservation",
+                        "default_subject": "Area reservation requirement",
+                        "default_from_email": abuse_email_address,
+                        "default_cc_emails": "",
                     }
                     rendered_message = render_email_template(message, dictionary)
+                    subject, from_email, cc = resolve_email_customization("unauthorized_tool_access_email", dictionary)
                     send_mail(
-                        subject="Area reservation requirement",
+                        subject=subject,
                         content=rendered_message,
-                        from_email=abuse_email_address,
+                        from_email=from_email,
                         to=[abuse_email_address],
+                        cc=cc,
                         email_category=EmailCategory.ABUSE,
                     )
                 return HttpResponseBadRequest(

--- a/NEMO/templates/customizations/customizations.html
+++ b/NEMO/templates/customizations/customizations.html
@@ -41,6 +41,40 @@
 			    return true;
 			}
         }
-	
+
+        // Reads the newly selected file as text and shows it in the matching content textarea
+        function load_file_into_textarea(file_input, textarea_id)
+        {
+            if (file_input.files && file_input.files.length > 0)
+            {
+                let reader = new FileReader();
+                reader.onload = function(event)
+                {
+                    let textarea = document.getElementById(textarea_id);
+                    if (textarea)
+                    {
+                        textarea.value = event.target.result;
+                    }
+                };
+                reader.readAsText(file_input.files[0]);
+            }
+        }
+
+        // If no new file was picked, saves whatever is currently in the content textarea instead
+        // (so editing the textarea directly and clicking upload works without choosing a file first)
+        function sync_textarea_before_submit(name, extension)
+        {
+            let file_input = $('input[name='+name+']')[0];
+            let textarea = document.getElementById(name + '_content');
+            if (file_input && textarea && file_input.files.length === 0)
+            {
+                let blob = new Blob([textarea.value], {type: 'text/plain'});
+                let file = new File([blob], name + '.' + extension, {type: 'text/plain'});
+                let data_transfer = new DataTransfer();
+                data_transfer.items.add(file);
+                file_input.files = data_transfer.files;
+            }
+            return true;
+        }
     </script>
 {% endblock %}

--- a/NEMO/templates/customizations/customizations_email_options.html
+++ b/NEMO/templates/customizations/customizations_email_options.html
@@ -1,0 +1,57 @@
+{% load custom_tags_and_filters %}
+{% with subject_key=element|concat:"_subject" from_key=element|concat:"_from" cc_key=element|concat:"_cc" %}
+    {% if request.GET.saved == element %}
+        <div class="alert alert-success">This email's subject, from, and cc settings were saved successfully.</div>
+    {% endif %}
+    <div class="form-horizontal" style="margin-bottom: 15px">
+        <div class="form-group">
+            <label class="control-label col-sm-2" for="{{ element }}_subject_input">Subject</label>
+            <div class="col-sm-8">
+                <input type="text"
+                       form="email_settings_form"
+                       id="{{ element }}_subject_input"
+                       name="{{ subject_key }}"
+                       class="form-control"
+                       oninput="document.getElementById('{{ element }}_hidden_subject').value = this.value"
+                       value="{{ customizations|get_item:subject_key }}">
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="control-label col-sm-2" for="{{ element }}_from_input">From</label>
+            <div class="col-sm-8">
+                <input type="text"
+                       form="email_settings_form"
+                       id="{{ element }}_from_input"
+                       name="{{ from_key }}"
+                       class="form-control"
+                       list="email_from_presets"
+                       oninput="document.getElementById('{{ element }}_hidden_from').value = this.value"
+                       value="{{ customizations|get_item:from_key }}">
+            </div>
+        </div>
+        <div class="form-group" style="margin-bottom: 10px">
+            <label class="control-label col-sm-2" for="{{ element }}_cc_input">Cc</label>
+            <div class="col-sm-8">
+                <input type="text"
+                       form="email_settings_form"
+                       id="{{ element }}_cc_input"
+                       name="{{ cc_key }}"
+                       class="form-control"
+                       oninput="document.getElementById('{{ element }}_hidden_cc').value = this.value"
+                       value="{{ customizations|get_item:cc_key }}"
+                       placeholder="Comma-separated addresses or template variables">
+            </div>
+        </div>
+        <div class="form-group" style="margin-bottom: 0">
+            <div class="col-sm-offset-2 col-sm-8">
+                <form method="POST" action="{% url 'customize' 'templates' element|concat:'_fields' %}#{{ element }}_id">
+                    {% csrf_token %}
+                    <input type="hidden" id="{{ element }}_hidden_subject" name="{{ subject_key }}" value="{{ customizations|get_item:subject_key }}">
+                    <input type="hidden" id="{{ element }}_hidden_from" name="{{ from_key }}" value="{{ customizations|get_item:from_key }}">
+                    <input type="hidden" id="{{ element }}_hidden_cc" name="{{ cc_key }}" value="{{ customizations|get_item:cc_key }}">
+                    {% button type="save" value="Save this email's settings" size="small" %}
+                </form>
+            </div>
+        </div>
+    </div>
+{% endwith %}

--- a/NEMO/templates/customizations/customizations_templates.html
+++ b/NEMO/templates/customizations/customizations_templates.html
@@ -1,5 +1,44 @@
 {% load custom_tags_and_filters %}
 <div class="panel-body">
+    <h3 class="customization-section-title" id="email_settings_id">Email settings</h3>
+    <p>
+        Each email below has a customizable subject, "from" address and "cc" addresses. Each of these three fields is
+        rendered with the Django template engine using the same context variables listed for that email, plus three
+        extra variables always available on every email:
+    </p>
+    <ul>
+        <li>
+            <code>default_subject</code> - {{ site_title }}'s original, built-in subject for that specific email
+        </li>
+        <li>
+            <code>default_from_email</code> - {{ site_title }}'s original, built-in "from" address for that specific email
+        </li>
+        <li>
+            <code>default_cc_emails</code> - {{ site_title }}'s original, built-in "cc" addresses for that specific email
+        </li>
+    </ul>
+    <p>
+        Note that you can generally edit these fields for each specific email through different customization settings. The From field will autopopulate with different presets you may use to access different email addresses.<br><br>
+        Leaving a field blank restores it to its original behavior. You may use any valid Django template syntax, including template variables (e.g.
+        <code>{% templatetag openvariable %} customizations|get_item:"user_office_email_address" {% templatetag closevariable %}</code>).
+        <br><br>
+        Each email has its own "Save this email's settings" button right below its subject/from/cc fields, which saves only that email. The
+        "Save all email settings" buttons here and at the bottom of the page save every email at once.
+    </p>
+    <form id="email_settings_form" method="POST" action="{% url 'customize' 'templates' %}" style="margin-bottom: 20px; margin-top: 20px">
+        {% csrf_token %}
+        <div class="text-center">{% button type="save" value="Save all email settings" %}</div>
+    </form>
+    <datalist id="email_from_presets">
+        <option value="{% templatetag openvariable %} default_from_email {% templatetag closevariable %}" label="Default (unchanged)"></option>
+        <option value="{% templatetag openvariable %} customizations|get_item:&quot;user_office_email_address&quot; {% templatetag closevariable %}" label="User office"></option>
+        <option value="{% templatetag openvariable %} customizations|get_item:&quot;abuse_email_address&quot; {% templatetag closevariable %}" label="Abuse"></option>
+        <option value="{% templatetag openvariable %} customizations|get_item:&quot;safety_email_address&quot; {% templatetag closevariable %}" label="Safety"></option>
+        <option value="{% templatetag openvariable %} customizations|get_item:&quot;feedback_email_address&quot; {% templatetag closevariable %}" label="Feedback"></option>
+    </datalist>
+    <div class="customization-separation"></div>
+</div>
+<div class="panel-body">
     <h3 class="customization-section-title" id="login_banner_id">Login banner</h3>
     <p>
         The login banner is an informational message displayed underneath the username and password text boxes on the login page. You can customize this to convey rules for {{ site_title }} users at your organization.
@@ -62,7 +101,7 @@
         <br>
         The image you upload should be a valid image file (recommended size is 1500x1000).
     </p>
-    {% include 'customizations/customizations_upload.html' with element=jumbotron_watermark name='jumbotron watermark' extension='png' key='templates' %}
+    {% include 'customizations/customizations_upload.html' with element=jumbotron_watermark name='jumbotron watermark' extension='png' uneditable=True key='templates' %}
     <div class="customization-separation"></div>
 </div>
 <div id="panel-sort">
@@ -76,18 +115,19 @@
         <p>The following context variables are provided when the email is rendered:</p>
         <ul>
             <li>
-                <b>template_color</b> - the color: green if approved, red if denied, blue otherwise
+                <code>template_color</code> - the color: green if approved, red if denied, blue otherwise
             </li>
             <li>
-                <b>access_request</b> - the user's access request that was created or updated
+                <code>access_request</code> - the user's access request that was created or updated
             </li>
             <li>
-                <b>status</b> - the status of the request: received, updated, approved or denied
+                <code>status</code> - the status of the request: received, updated, approved or denied
             </li>
             <li>
-                <b>access_requests_url</b> - the URL to the access requests page
+                <code>access_requests_url</code> - the URL to the access requests page
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='access_request_notification_email' %}
         {% include 'customizations/customizations_upload.html' with element=access_request_notification_email name='access request notification email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -102,24 +142,25 @@
         <p>The following context variables are provided when the email is rendered:</p>
         <ul>
             <li>
-                <b>template_color</b> - the color: green if approved, red if denied, blue otherwise
+                <code>template_color</code> - the color: green if approved, red if denied, blue otherwise
             </li>
             <li>
-                <b>adjustment_request</b> - the user's adjustment request that was created or updated
+                <code>adjustment_request</code> - the user's adjustment request that was created or updated
             </li>
             <li>
-                <b>status</b> - the status of the request: received, updated, approved or denied
+                <code>status</code> - the status of the request: received, updated, approved or denied
             </li>
             <li>
-                <b>adjustment_requests_url</b> - the URL to the adjustment requests page
+                <code>adjustment_requests_url</code> - the URL to the adjustment requests page
             </li>
             <li>
-                <b>manager_note</b> - an extra (optional) note from the manager sent to the user when the request is denied or to the user office when it is approved
+                <code>manager_note</code> - an extra (optional) note from the manager sent to the user when the request is denied or to the user office when it is approved
             </li>
             <li>
-                <b>user_office</b> - a flag that is true when the email is addressed to the User Office
+                <code>user_office</code> - a flag that is true when the email is addressed to the User Office
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='adjustment_request_notification_email' %}
         {% include 'customizations/customizations_upload.html' with element=adjustment_request_notification_email name='adjustment request notification email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -129,15 +170,16 @@
         <p>The following context variables are provided when the email is rendered:</p>
         <ul>
             <li>
-                <b>user</b> - the user in the wait list
+                <code>user</code> - the user in the wait list
             </li>
             <li>
-                <b>tool</b> - the tool that the user is in the wait list for
+                <code>tool</code> - the tool that the user is in the wait list for
             </li>
             <li>
-                <b>time_to_expiration</b> - the time left for the user to use the tool
+                <code>time_to_expiration</code> - the time left for the user to use the tool
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='wait_list_notification_email' %}
         {% include 'customizations/customizations_upload.html' with element=wait_list_notification_email name='wait list notification email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -148,15 +190,16 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the user's reservation that was cancelled
+                <code>reservation</code> - the user's reservation that was cancelled
             </li>
             <li>
-                <b>staff_member</b> - the user object of the staff member who cancelled the reservation
+                <code>staff_member</code> - the user object of the staff member who cancelled the reservation
             </li>
             <li>
-                <b>reason</b> - the reason the staff member provided for cancelling the reservation
+                <code>reason</code> - the reason the staff member provided for cancelling the reservation
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='cancellation_email' %}
         {% include 'customizations/customizations_upload.html' with element=cancellation_email name='cancellation email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -168,9 +211,10 @@
         </p>
         <ul>
             <li>
-                <b>counter</b> - the counter which value reached the warning threshold
+                <code>counter</code> - the counter which value reached the warning threshold
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='counter_threshold_reached_email' %}
         {% include 'customizations/customizations_upload.html' with element=counter_threshold_reached_email name='counter threshold reached email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -182,12 +226,13 @@
         </p>
         <ul>
             <li>
-                <b>contents</b> - the user's feedback
+                <code>contents</code> - the user's feedback
             </li>
             <li>
-                <b>user</b> - the user object of the user who submitted the feedback
+                <code>user</code> - the user object of the user who submitted the feedback
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='feedback_email' %}
         {% include 'customizations/customizations_upload.html' with element=feedback_email name='feedback email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -198,18 +243,19 @@
         </p>
         <ul>
             <li>
-                <b>title</b> - the user specified title of the email
+                <code>title</code> - the user specified title of the email
             </li>
             <li>
-                <b>greeting</b> - a greeting to the recipients of the email
+                <code>greeting</code> - a greeting to the recipients of the email
             </li>
             <li>
-                <b>contents</b> - the body of the email
+                <code>contents</code> - the body of the email
             </li>
             <li>
-                <b>template_color</b> - the color to emphasize
+                <code>template_color</code> - the color to emphasize
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='generic_email' %}
         {% include 'customizations/customizations_upload.html' with element=generic_email name='generic email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -222,9 +268,10 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the reservation that the user missed
+                <code>reservation</code> - the reservation that the user missed
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='missed_reservation_email' %}
         {% include 'customizations/customizations_upload.html' with element=missed_reservation_email name='missed reservation email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -239,12 +286,16 @@
         </p>
         <ul>
             <li>
-                <b>user</b> - the user's model instance
+                <code>user</code> - the user's model instance
             </li>
             <li>
-                <b>making_reservations_rule_summary</b> - a free-response answer provided by the user. Normally, this is provided by the user to summarize their understanding of the {{ facility_name }} rules and proceedures.
+                <code>making_reservations_rule_summary</code> - a free-response answer provided by the user. Normally, this is provided by the user to summarize their understanding of the {{ facility_name }} rules and proceedures.
+            </li>
+            <li>
+                <code>facility_name</code> - the name of the facility
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='facility_rules_tutorial_email' %}
         {% include 'customizations/customizations_upload.html' with element=facility_rules_tutorial_email name='facility rules tutorial email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -256,21 +307,22 @@
         </p>
         <ul>
             <li>
-                <b>user</b> - the user who created the task
+                <code>user</code> - the user who created the task
             </li>
             <li>
-                <b>task</b> - the task information
+                <code>task</code> - the task information
             </li>
             <li>
-                <b>tool</b> - the tool that the task is associated with
+                <code>tool</code> - the tool that the task is associated with
             </li>
             <li>
-                <b>tool_control_absolute_url</b> - the URL of the tool control page for the tool
+                <code>tool_control_absolute_url</code> - the URL of the tool control page for the tool
             </li>
             <li>
-                <b>template_color</b> - an HTML color code indicating the severity of the problem. Orange for warning, red for shutdown.
+                <code>template_color</code> - an HTML color code indicating the severity of the problem. Orange for warning, red for shutdown.
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='new_task_email' %}
         {% include 'customizations/customizations_upload.html' with element=new_task_email name='new task email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -282,9 +334,10 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the reservation that the user is out of time on
+                <code>reservation</code> - the reservation that the user is out of time on
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='out_of_time_reservation_email' %}
         {% include 'customizations/customizations_upload.html' with element=out_of_time_reservation_email name='out of time reservation email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -298,16 +351,20 @@
         </p>
         <ul>
             <li>
-                <b>user</b> - the user who is assigned to the items
+                <code>user</code> - the user who is assigned to the items
             </li>
             <li>
-                <b>charges</b> - the list of {{ recurring_charges_name|lower }}
+                <code>charges</code> - the list of {{ recurring_charges_name|lower }}
             </li>
             <li>
-                <b>reminder_days</b> - the number of days until the items are charged
+                <code>reminder_days</code> - the number of days until the items are charged
+            </li>
+            <li>
+                <code>recurring_charges_name</code> - the configured name for {{ recurring_charges_name|lower }}
             </li>
         </ul>
         {% with button_name=recurring_charges_name|lower %}
+            {% include 'customizations/customizations_email_options.html' with element='recurring_charges_reminder_email' %}
             {% include 'customizations/customizations_upload.html' with element=recurring_charges_reminder_email name="recurring charges reminder email" button_name="Upload "|concat:button_name|concat:" reminder email" element_link_name=button_name.split|join:"_"|concat:"_reminder_email" key='templates' %}
         {% endwith %}
         <div class="customization-separation"></div>
@@ -320,9 +377,10 @@
         </p>
         <ul>
             <li>
-                <b>item</b> - the item which quantity fell below the reminder threshold
+                <code>item</code> - the item which quantity fell below the reminder threshold
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='reorder_supplies_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=reorder_supplies_reminder_email name='reorder supplies reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -336,9 +394,10 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the user's reservation ending
+                <code>reservation</code> - the user's reservation ending
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='reservation_ending_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=reservation_ending_reminder_email name='reservation ending reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -351,9 +410,10 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the user's upcoming reservation
+                <code>reservation</code> - the user's upcoming reservation
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='reservation_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=reservation_reminder_email name='reservation reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -366,15 +426,16 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the user's upcoming reservation
+                <code>reservation</code> - the user's upcoming reservation
             </li>
             <li>
-                <b>fatal_error</b> - boolean value that, when true, indicates that it will be impossible for the user to use the tool/access the area during their reservation (due to maintenance, outages or a missing required dependency)
+                <code>fatal_error</code> - boolean value that, when true, indicates that it will be impossible for the user to use the tool/access the area during their reservation (due to maintenance, outages or a missing required dependency)
             </li>
             <li>
-                <b>template_color</b> - an HTML color code indicating the severity of the problem. Orange for warning, red for shutdown.
+                <code>template_color</code> - an HTML color code indicating the severity of the problem. Orange for warning, red for shutdown.
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='reservation_warning_email' %}
         {% include 'customizations/customizations_upload.html' with element=reservation_warning_email name='reservation warning email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -386,12 +447,13 @@
         </p>
         <ul>
             <li>
-                <b>issue</b> - the issue information
+                <code>issue</code> - the issue information
             </li>
             <li>
-                <b>issue_absolute_url</b> - the URL for the detailed view of the issue
+                <code>issue_absolute_url</code> - the URL for the detailed view of the issue
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='safety_issue_email' %}
         {% include 'customizations/customizations_upload.html' with element=safety_issue_email name='safety issue email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -403,9 +465,10 @@
         </p>
         <ul>
             <li>
-                <b>outage</b> - the upcoming scheduled outage
+                <code>outage</code> - the upcoming scheduled outage
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='scheduled_outage_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=scheduled_outage_reminder_email name='scheduled outage reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -417,9 +480,10 @@
         </p>
         <ul>
             <li>
-                <b>staff_charge</b> - the staff charge that is in progress
+                <code>staff_charge</code> - the staff charge that is in progress
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='staff_charge_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=staff_charge_reminder_email name='staff charge reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -431,24 +495,25 @@
         </p>
         <ul>
             <li>
-                <b>template_color</b> - the color to emphasize
+                <code>template_color</code> - the color to emphasize
             </li>
             <li>
-                <b>title</b> - a title indicating that the message is a task status notification
+                <code>title</code> - a title indicating that the message is a task status notification
             </li>
             <li>
-                <b>task</b> - the task that was updated
+                <code>task</code> - the task that was updated
             </li>
             <li>
-                <b>status_message</b> - the current status message for the task
+                <code>status_message</code> - the current status message for the task
             </li>
             <li>
-                <b>notification_message</b> - the notification message that is configured (via the admin site) for the status
+                <code>notification_message</code> - the notification message that is configured (via the admin site) for the status
             </li>
             <li>
-                <b>tool_control_absolute_url</b> - the URL of the tool control page for the task
+                <code>tool_control_absolute_url</code> - the URL of the tool control page for the task
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='task_status_notification' %}
         {% include 'customizations/customizations_upload.html' with element=task_status_notification name='task status notification' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -462,24 +527,25 @@
         </p>
         <ul>
             <li>
-                <b>remaining_days</b> - the number of days left before the qualification expires. This variable is only provided when a reminder is sent
+                <code>remaining_days</code> - the number of days left before the qualification expires. This variable is only provided when a reminder is sent
             </li>
             <li>
-                <b>expiration_date</b> - the date the tool qualification expires
+                <code>expiration_date</code> - the date the tool qualification expires
             </li>
             <li>
-                <b>user</b> - the user whose qualification is expiring
+                <code>user</code> - the user whose qualification is expiring
             </li>
             <li>
-                <b>tool</b> - the tool whose qualification is expiring
+                <code>tool</code> - the tool whose qualification is expiring
             </li>
             <li>
-                <b>last_tool_use</b> - the last time the tool was used. Blank if the user never used the tool
+                <code>last_tool_use</code> - the last time the tool was used. Blank if the user never used the tool
             </li>
             <li>
-                <b>qualification_date</b> - the time the user was last qualified on that tool
+                <code>qualification_date</code> - the time the user was last qualified on that tool
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='tool_qualification_expiration_email' %}
         {% include 'customizations/customizations_upload.html' with element=tool_qualification_expiration_email name='tool qualification expiration email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -493,18 +559,19 @@
         <p>The following context variables are provided when the email is rendered:</p>
         <ul>
             <li>
-                <b>user</b> - the user who was using the tool
+                <code>user</code> - the user who was using the tool
             </li>
             <li>
-                <b>tool</b> - the tool the user was using
+                <code>tool</code> - the tool the user was using
             </li>
             <li>
-                <b>questions</b> - the questions the user needs to answer
+                <code>questions</code> - the questions the user needs to answer
             </li>
             <li>
-                <b>usage_event</b> - the usage event
+                <code>usage_event</code> - the usage event
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='tool_required_unanswered_questions_email' %}
         {% include 'customizations/customizations_upload.html' with element=tool_required_unanswered_questions_email name='tool required unanswered questions email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -518,15 +585,16 @@
         <p>The following context variables are provided when the email is rendered:</p>
         <ul>
             <li>
-                <b>operator</b> - the person who attempted to use the tool
+                <code>operator</code> - the person who attempted to use the tool
             </li>
             <li>
-                <b>tool</b> - the tool that the user was denied access to
+                <code>tool</code> - the tool that the user was denied access to
             </li>
             <li>
-                <b>type</b> - the type of abuse ('area-access' or 'area-reservation')
+                <code>type</code> - the type of abuse ('area-access' or 'area-reservation')
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='unauthorized_tool_access_email' %}
         {% include 'customizations/customizations_upload.html' with element=unauthorized_tool_access_email name='unauthorized tool access email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -538,12 +606,16 @@
         </p>
         <ul>
             <li>
-                <b>user</b> - the user who is using a tool or logged in to an area
+                <code>user</code> - the user who is using a tool or logged in to an area
             </li>
             <li>
-                <b>resources_in_use</b> - the resources the user is still using/logged in to (tools or areas)
+                <code>resources_in_use</code> - the resources the user is still using/logged in to (tools or areas)
+            </li>
+            <li>
+                <code>facility_name</code> - the name of the facility
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='usage_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=usage_reminder_email name='usage reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -557,12 +629,16 @@
         </p>
         <ul>
             <li>
-                <b>user</b> - the user whose access is expiring
+                <code>user</code> - the user whose access is expiring
             </li>
             <li>
-                <b>remaining_days</b> - the remaining days before the access expires
+                <code>remaining_days</code> - the remaining days before the access expires
+            </li>
+            <li>
+                <code>facility_name</code> - the name of the facility
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='user_access_expiration_reminder_email' %}
         {% include 'customizations/customizations_upload.html' with element=user_access_expiration_reminder_email name='user access expiration reminder email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -578,9 +654,10 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the user's reservation that was created
+                <code>reservation</code> - the user's reservation that was created
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='reservation_created_user_email' %}
         {% include 'customizations/customizations_upload.html' with element=reservation_created_user_email name='reservation created user email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -596,9 +673,10 @@
         </p>
         <ul>
             <li>
-                <b>reservation</b> - the user's reservation that was cancelled
+                <code>reservation</code> - the user's reservation that was cancelled
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='reservation_cancelled_user_email' %}
         {% include 'customizations/customizations_upload.html' with element=reservation_cancelled_user_email name='reservation cancelled user email' key='templates' %}
         <div class="customization-separation"></div>
     </div>
@@ -620,16 +698,29 @@
         <p>The following context variables are provided when the email is rendered:</p>
         <ul>
             <li>
-                <b>weekend_access</b> - true/false, whether there are approved weekend access requests for the current week.
+                <code>weekend_access</code> - true/false, whether there are approved weekend access requests for the current week.
+            </li>
+            <li>
+                <code>facility_name</code> - the name of the facility
+            </li>
+            <li>
+                <code>sat</code> - the date of the upcoming Saturday, already formatted for display
+            </li>
+            <li>
+                <code>sun</code> - the date of the upcoming Sunday, already formatted for display
             </li>
         </ul>
+        {% include 'customizations/customizations_email_options.html' with element='weekend_access_email' %}
         {% include 'customizations/customizations_upload.html' with element=weekend_access_email name='weekend access email' key='templates' %}
     </div>
-    {% for customization_instance in customization.instances %}
-        {% if customization_instance.template_templates %}
-            {% include customization_instance.template_templates %}
-        {% endif %}
-    {% endfor %}
+</div>
+{% for customization_instance in customization.instances %}
+    {% if customization_instance.template_templates %}
+        {% include customization_instance.template_templates %}
+    {% endif %}
+{% endfor %}
+<div class="text-center" style="margin-bottom: 20px;">
+    {% button type="save" value="Save all email settings" form="email_settings_form" %}
 </div>
 <script>
     function sort_comp(element)

--- a/NEMO/templates/customizations/customizations_upload.html
+++ b/NEMO/templates/customizations/customizations_upload.html
@@ -9,7 +9,11 @@
             <input type="file"
                    name="{{ element_name }}"
                    class="customization-input-file"
-                   onchange="this.style.color = 'inherit';$('#{{ element_name }}_span').hide()">
+                   {% if uneditable %}
+                   onchange="this.style.color = 'inherit';$('#{{ element_name }}_span').hide()"
+                   {% else %}
+                   onchange="this.style.color = 'inherit';$('#{{ element_name }}_span').hide();load_file_into_textarea(this, '{{ element_name }}_content');"
+                   {% endif %}>
             {% if element %}
                 <a id="{{ element_name }}_span"
                    href="{% get_media_prefix %}{{ element_name }}.{{ extension }}"
@@ -17,10 +21,23 @@
                    target="_blank">{{ element_link_name|default:element_name }}.{{ extension }}</a>
             {% endif %}
         </div>
+        {% if not uneditable %}
+            <div class="form-group" style="margin-top: 10px">
+                <textarea id="{{ element_name }}_content"
+                          class="form-control"
+                          style="font-family: monospace, monospace; font-size: 12px;"
+                          rows="12"
+                          spellcheck="false">{{ element }}</textarea>
+            </div>
+        {% endif %}
         <div class="form-group">
             <div style="display: inline-block;margin-right:15px;margin-top: 15px">
                 {% with upload_button_name="Upload "|concat:name %}
-                    {% button type="save" value=button_name|default:upload_button_name onclick="return check_delete_file_before_submit('"|concat:element_name|concat:"') && submit_and_disable(this);" icon="glyphicon-floppy-open" %}
+                    {% if uneditable %}
+                        {% button type="save" value=button_name|default:upload_button_name onclick="return check_delete_file_before_submit('"|concat:element_name|concat:"') && submit_and_disable(this);" icon="glyphicon-floppy-open" %}
+                    {% else %}
+                        {% button type="save" value=button_name|default:upload_button_name onclick="return sync_textarea_before_submit('"|concat:element_name|concat:"', '"|concat:extension|concat:"') && submit_and_disable(this);" icon="glyphicon-floppy-open" %}
+                    {% endif %}
                 {% endwith %}
             </div>
             {% if element and not hide_content %}
@@ -30,5 +47,8 @@
                 </div>
             {% endif %}
         </div>
+        {% if request.GET.file_saved == element_name %}
+            <div class="alert alert-success">{{ name|capfirst }} was saved successfully.</div>
+        {% endif %}
     </form>
 {% endwith %}

--- a/NEMO/tests/test_email_customization.py
+++ b/NEMO/tests/test_email_customization.py
@@ -1,0 +1,300 @@
+from unittest.mock import patch
+
+from django.core import mail
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.urls import reverse
+
+from NEMO.models import User
+from NEMO.tests.test_utilities import NEMOTestCaseMixin
+from NEMO.views.customization import (
+    EMAIL_TEMPLATE_NAMES,
+    EmailsCustomization,
+    TemplatesCustomization,
+    resolve_email_customization,
+)
+
+
+class ResolveEmailCustomizationTestCase(NEMOTestCaseMixin, TestCase):
+    def setUp(self):
+        self.dictionary = {
+            "default_subject": "Original subject",
+            "default_from_email": "orig@example.com",
+            "default_cc_emails": "a@example.com, b@example.com",
+        }
+        # The backfill migration backfills real subject templates for these two, which would otherwise make the
+        # "not customized" tests below fail. These tests are about resolve_email_customization()'s generic
+        # override/passthrough/independence mechanics, not migration content, so we start from a clean slate.
+        from NEMO.models import Customization
+
+        Customization.objects.filter(
+            name__in=[
+                "new_task_email_subject",
+                "new_task_email_from",
+                "new_task_email_cc",
+                "task_status_notification_subject",
+                "task_status_notification_from",
+                "task_status_notification_cc",
+            ]
+        ).delete()
+
+    def test_defaults_pass_through_when_not_customized(self):
+        subject, from_email, cc = resolve_email_customization("new_task_email", self.dictionary)
+        self.assertEqual(subject, "Original subject")
+        self.assertEqual(from_email, "orig@example.com")
+        self.assertEqual(cc, ["a@example.com", "b@example.com"])
+
+    def test_customized_subject_can_reference_default_subject(self):
+        TemplatesCustomization.set("new_task_email_subject", "Custom: {{ default_subject }}")
+        subject, from_email, cc = resolve_email_customization("new_task_email", self.dictionary)
+        self.assertEqual(subject, "Custom: Original subject")
+        # from/cc remain at their (unset) defaults
+        self.assertEqual(from_email, "orig@example.com")
+        self.assertEqual(cc, ["a@example.com", "b@example.com"])
+
+    def test_customized_from_overrides_default(self):
+        TemplatesCustomization.set("new_task_email_from", "override@example.com")
+        _, from_email, _ = resolve_email_customization("new_task_email", self.dictionary)
+        self.assertEqual(from_email, "override@example.com")
+
+    def test_cc_is_split_stripped_and_empty_entries_dropped(self):
+        TemplatesCustomization.set("new_task_email_cc", "c@example.com,  d@example.com , , ")
+        _, _, cc = resolve_email_customization("new_task_email", self.dictionary)
+        self.assertEqual(cc, ["c@example.com", "d@example.com"])
+
+    def test_cc_can_reference_arbitrary_context_variables(self):
+        dictionary = dict(self.dictionary, extra_cc="extra@example.com")
+        TemplatesCustomization.set("new_task_email_cc", "{{ default_cc_emails }}, {{ extra_cc }}")
+        _, _, cc = resolve_email_customization("new_task_email", dictionary)
+        self.assertEqual(cc, ["a@example.com", "b@example.com", "extra@example.com"])
+
+    def test_resetting_to_empty_falls_back_to_default(self):
+        TemplatesCustomization.set("new_task_email_subject", "Custom")
+        TemplatesCustomization.set("new_task_email_subject", "")
+        subject, _, _ = resolve_email_customization("new_task_email", self.dictionary)
+        self.assertEqual(subject, "Original subject")
+
+    def test_different_templates_are_independent(self):
+        TemplatesCustomization.set("new_task_email_subject", "New task custom subject")
+        subject, _, _ = resolve_email_customization("task_status_notification", self.dictionary)
+        self.assertEqual(subject, "Original subject")
+
+
+class TemplatesCustomizationEmailVariablesTestCase(NEMOTestCaseMixin, TestCase):
+    def test_every_email_template_has_subject_from_cc_variables(self):
+        for name in EMAIL_TEMPLATE_NAMES:
+            self.assertIn(f"{name}_subject", TemplatesCustomization.variables)
+            self.assertIn(f"{name}_from", TemplatesCustomization.variables)
+            self.assertIn(f"{name}_cc", TemplatesCustomization.variables)
+
+    def test_variable_count_matches_three_per_email_template(self):
+        email_variable_names = [
+            key
+            for key in TemplatesCustomization.variables
+            if key.endswith(("_subject", "_from", "_cc")) and key.rsplit("_", 1)[0] in EMAIL_TEMPLATE_NAMES
+        ]
+        self.assertEqual(len(email_variable_names), len(EMAIL_TEMPLATE_NAMES) * 3)
+
+    def test_non_email_files_do_not_get_subject_variables(self):
+        # login_banner is a files entry but not an actual email - it must not get subject/from/cc variables
+        self.assertNotIn("login_banner_subject", TemplatesCustomization.variables)
+        self.assertNotIn("jumbotron_watermark_subject", TemplatesCustomization.variables)
+
+    def test_defaults_are_passthrough_templates(self):
+        # The class-level Python default (used whenever a template has no DB row at all - e.g. a template the
+        # backfill migration doesn't touch, or one an admin has reset to blank) must still be the plain passthrough.
+        self.assertEqual(TemplatesCustomization.variables["feedback_email_subject"], "{{ default_subject }}")
+        self.assertEqual(TemplatesCustomization.variables["feedback_email_from"], "{{ default_from_email }}")
+        self.assertEqual(TemplatesCustomization.variables["feedback_email_cc"], "{{ default_cc_emails }}")
+
+
+@patch("django.core.files.storage.FileSystemStorage.exists")
+@patch("django.core.files.storage.FileSystemStorage._open")
+class FeedbackEmailCustomizationEndToEndTestCase(NEMOTestCaseMixin, TestCase):
+    """Verifies a customized subject/from/cc is actually used when an email is sent, via the feedback view."""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username="feedback_user", first_name="Feed", last_name="Back", email="feedback_user@example.com"
+        )
+        EmailsCustomization.set("feedback_email_address", "recipient@example.com")
+
+    def tearDown(self):
+        TemplatesCustomization.set("feedback_email_subject", "")
+        TemplatesCustomization.set("feedback_email_from", "")
+        TemplatesCustomization.set("feedback_email_cc", "")
+        super().tearDown()
+
+    def test_default_subject_and_from_are_used_when_not_customized(self, mock_open, mock_exists):
+        mock_exists.return_value = True
+        mock_open.return_value = ContentFile(b"<p>{{ contents }}</p>", name="feedback_email.html")
+        self.login_as(self.user)
+        self.client.post("/feedback/", {"feedback": "Hello there"})
+        self.assertEqual(len(mail.outbox), 1)
+        sent = mail.outbox[0]
+        self.assertEqual(sent.subject, "Feedback from " + str(self.user))
+        self.assertEqual(sent.from_email, self.user.email)
+        self.assertEqual(sent.cc, [])
+
+    def test_customized_subject_from_and_cc_are_used_when_sending(self, mock_open, mock_exists):
+        mock_exists.return_value = True
+        mock_open.return_value = ContentFile(b"<p>{{ contents }}</p>", name="feedback_email.html")
+        TemplatesCustomization.set("feedback_email_subject", "Custom: {{ default_subject }}")
+        TemplatesCustomization.set("feedback_email_from", "override@example.com")
+        TemplatesCustomization.set("feedback_email_cc", "cc1@example.com, cc2@example.com")
+        self.login_as(self.user)
+        self.client.post("/feedback/", {"feedback": "Hello there"})
+        self.assertEqual(len(mail.outbox), 1)
+        sent = mail.outbox[0]
+        self.assertEqual(sent.subject, "Custom: Feedback from " + str(self.user))
+        self.assertEqual(sent.from_email, "override@example.com")
+        # send_mail() de-duplicates recipients via a set, so cc order isn't guaranteed
+        self.assertEqual(sorted(sent.cc), ["cc1@example.com", "cc2@example.com"])
+
+
+class CustomizeTemplatesViewTestCase(NEMOTestCaseMixin, TestCase):
+    """Verifies the shared 'email settings' form saves every template's fields together without wiping others."""
+
+    def test_saving_one_template_does_not_wipe_others(self):
+        staff = self.login_as_staff()
+        staff.is_superuser = True
+        staff.save()
+
+        # Give a couple of templates a pre-existing customization
+        TemplatesCustomization.set("task_status_notification_subject", "Pre-existing subject")
+        TemplatesCustomization.set("safety_issue_email_from", "safety-override@example.com")
+
+        post_data = {}
+        for name in EMAIL_TEMPLATE_NAMES:
+            post_data[f"{name}_subject"] = TemplatesCustomization.get(f"{name}_subject")
+            post_data[f"{name}_from"] = TemplatesCustomization.get(f"{name}_from")
+            post_data[f"{name}_cc"] = TemplatesCustomization.get(f"{name}_cc")
+
+        # Only change feedback_email's fields in this submission
+        post_data["feedback_email_subject"] = "Newly customized subject"
+        post_data["feedback_email_from"] = "new-from@example.com"
+        post_data["feedback_email_cc"] = "someone@example.com"
+
+        response = self.client.post(reverse("customize", args=["templates"]), post_data)
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(TemplatesCustomization.get("feedback_email_subject"), "Newly customized subject")
+        self.assertEqual(TemplatesCustomization.get("feedback_email_from"), "new-from@example.com")
+        self.assertEqual(TemplatesCustomization.get("feedback_email_cc"), "someone@example.com")
+        # The pre-existing customizations on other templates must survive this save untouched
+        self.assertEqual(TemplatesCustomization.get("task_status_notification_subject"), "Pre-existing subject")
+        self.assertEqual(TemplatesCustomization.get("safety_issue_email_from"), "safety-override@example.com")
+
+    def test_customization_page_renders_all_email_fields(self):
+        staff = self.login_as_staff()
+        staff.is_superuser = True
+        staff.save()
+        response = self.client.get(reverse("customization", args=["templates"]))
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('id="email_settings_form"', content)
+        for name in EMAIL_TEMPLATE_NAMES:
+            self.assertIn(f'name="{name}_subject"', content)
+            self.assertIn(f'name="{name}_from"', content)
+            self.assertIn(f'name="{name}_cc"', content)
+
+
+class PerTemplateSaveTestCase(NEMOTestCaseMixin, TestCase):
+    """The per-template 'Save this email's settings' button must save only that one template's fields."""
+
+    def setUp(self):
+        staff = self.login_as_staff()
+        staff.is_superuser = True
+        staff.save()
+
+    def test_saving_one_template_via_the_fields_element_does_not_touch_others(self):
+        TemplatesCustomization.set("task_status_notification_subject", "Pre-existing subject")
+        TemplatesCustomization.set("safety_issue_email_from", "safety-override@example.com")
+
+        response = self.client.post(
+            reverse("customize", args=["templates", "feedback_email_fields"]),
+            {
+                "feedback_email_subject": "Newly customized subject",
+                "feedback_email_from": "new-from@example.com",
+                "feedback_email_cc": "someone@example.com",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("saved=feedback_email", response.url)
+        self.assertIn("#feedback_email_id", response.url)
+        self.assertEqual(TemplatesCustomization.get("feedback_email_subject"), "Newly customized subject")
+        self.assertEqual(TemplatesCustomization.get("feedback_email_from"), "new-from@example.com")
+        self.assertEqual(TemplatesCustomization.get("feedback_email_cc"), "someone@example.com")
+        # Untouched by this scoped save
+        self.assertEqual(TemplatesCustomization.get("task_status_notification_subject"), "Pre-existing subject")
+        self.assertEqual(TemplatesCustomization.get("safety_issue_email_from"), "safety-override@example.com")
+
+    def test_fields_element_that_is_not_a_real_email_template_falls_back_to_the_generic_save(self):
+        # "login_banner_fields" doesn't correspond to any email template, so this must behave like a normal
+        # (non-scoped) save rather than silently doing nothing or raising.
+        response = self.client.post(reverse("customize", args=["templates", "login_banner_fields"]), {})
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("saved=", response.url)
+
+    def test_inline_success_banner_shown_only_for_the_saved_template(self):
+        response = self.client.get(reverse("customization", args=["templates"]) + "?saved=feedback_email")
+        content = response.content.decode()
+        self.assertIn("This email's subject, from, and cc settings were saved successfully.", content)
+        # Only one banner should appear, not one per template
+        self.assertEqual(
+            content.count("This email's subject, from, and cc settings were saved successfully."), 1
+        )
+
+
+class FileUploadSaveMessageTestCase(NEMOTestCaseMixin, TestCase):
+    """Uploading a file (or saving the textarea) shows an inline confirmation under that element's own upload
+    button, distinct from and never confused with the subject/from/cc banner for the same element name."""
+
+    def setUp(self):
+        staff = self.login_as_staff()
+        staff.is_superuser = True
+        staff.save()
+
+    def test_uploading_a_file_redirects_with_file_saved_not_saved(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        response = self.client.post(
+            reverse("customize", args=["templates", "login_banner"]),
+            {"login_banner": SimpleUploadedFile("login_banner.html", b"<p>New banner</p>")},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("file_saved=login_banner", response.url)
+        self.assertIn("#login_banner_id", response.url)
+        self.assertNotIn("?saved=", response.url)
+
+    def test_file_saved_banner_shown_only_under_that_uploads_button(self):
+        response = self.client.get(reverse("customization", args=["templates"]) + "?file_saved=login_banner")
+        content = response.content.decode()
+        self.assertIn("Login banner was saved successfully.", content)
+        self.assertEqual(content.count("Login banner was saved successfully."), 1)
+
+    def test_file_saved_param_does_not_trigger_the_fields_banner_for_the_same_name(self):
+        # feedback_email is both a file-upload element and a subject/from/cc element; saving one must not
+        # make the other's banner appear.
+        response = self.client.get(reverse("customization", args=["templates"]) + "?file_saved=feedback_email")
+        content = response.content.decode()
+        self.assertIn("Feedback email was saved successfully.", content)
+        self.assertNotIn("This email's subject, from, and cc settings were saved successfully.", content)
+
+    def test_saved_param_does_not_trigger_the_file_banner_for_the_same_name(self):
+        response = self.client.get(reverse("customization", args=["templates"]) + "?saved=feedback_email")
+        content = response.content.decode()
+        self.assertIn("This email's subject, from, and cc settings were saved successfully.", content)
+        self.assertNotIn("Feedback email was saved successfully.", content)
+
+    def test_rates_customization_file_upload_also_gets_the_scoped_redirect(self):
+        # The mechanism is generic (any CustomizationBase subclass with a files list), not email-specific.
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        response = self.client.post(
+            reverse("customize", args=["rates", "rates"]),
+            {"rates": SimpleUploadedFile("rates.json", b"[]")},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("file_saved=rates", response.url)

--- a/NEMO/tests/test_email_subject_migration.py
+++ b/NEMO/tests/test_email_subject_migration.py
@@ -1,0 +1,337 @@
+"""
+Verifies that every subject template written by the 0158_backfill_email_subject_customizations data migration
+renders identically to what the original, hardcoded Python code originally computed for that email's subject,
+for every branch of every conditional. This is a content-fidelity check, as the migration must reproduce today's
+behavior exactly, not just be "close enough", since a wrong migrated value becomes the live subject for real
+emails the moment the migration runs.
+"""
+
+import importlib
+
+from django.test import TestCase
+
+from NEMO.tests.test_utilities import NEMOTestCaseMixin
+from NEMO.utilities import render_email_template
+
+migration_module = importlib.import_module(
+    "NEMO.migrations.0158_backfill_email_subject_customizations"
+)
+SUBJECT_TEMPLATES = migration_module.SUBJECT_TEMPLATES
+
+
+class Obj:
+    """A minimal stand-in for a model instance: arbitrary attributes, optional custom __str__."""
+
+    def __init__(self, _str=None, **kwargs):
+        self.__dict__.update(kwargs)
+        self._str = _str
+
+    def __str__(self):
+        return self._str if self._str is not None else super().__str__()
+
+
+class SubjectMigrationFidelityTestCase(NEMOTestCaseMixin, TestCase):
+    def render(self, template_name, context):
+        return render_email_template(SUBJECT_TEMPLATES[template_name], context)
+
+    def test_unauthorized_tool_access_email(self):
+        self.assertEqual(
+            self.render("unauthorized_tool_access_email", {"type": "area-access"}), "Area access requirement"
+        )
+        self.assertEqual(
+            self.render("unauthorized_tool_access_email", {"type": "area-reservation"}),
+            "Area reservation requirement",
+        )
+
+    def test_access_request_notification_email(self):
+        area = Obj(_str="Cleanroom")
+        access_request = Obj(physical_access_level=Obj(area=area))
+        for status in ("received", "updated"):
+            expected = f"Access request for the {area} {status}"
+            actual = self.render(
+                "access_request_notification_email", {"access_request": access_request, "status": status}
+            )
+            self.assertEqual(actual, expected)
+        for status in ("approved", "denied"):
+            expected = f"Your access request for the {area} has been {status}"
+            actual = self.render(
+                "access_request_notification_email", {"access_request": access_request, "status": status}
+            )
+            self.assertEqual(actual, expected)
+
+    def test_adjustment_request_notification_email(self):
+        creator = Obj(get_name=lambda: "Jane Doe")
+        adjustment_request = Obj(creator=creator)
+        for status in ("received", "updated"):
+            expected = f"Adjustment request {status}"
+            actual = self.render(
+                "adjustment_request_notification_email",
+                {"adjustment_request": adjustment_request, "status": status},
+            )
+            self.assertEqual(actual, expected)
+        for status in ("approved", "denied"):
+            expected = f"Your adjustment request has been {status}"
+            actual = self.render(
+                "adjustment_request_notification_email",
+                {"adjustment_request": adjustment_request, "status": status},
+            )
+            self.assertEqual(actual, expected)
+        status = "approved"
+        expected = f"{creator.get_name()}'s adjustment request has been {status}"
+        actual = self.render(
+            "adjustment_request_notification_email",
+            {"adjustment_request": adjustment_request, "status": status, "user_office": True},
+        )
+        self.assertEqual(actual, expected)
+
+    def test_cancellation_email(self):
+        self.assertEqual(self.render("cancellation_email", {}), "Your reservation was cancelled")
+
+    def test_counter_threshold_reached_email(self):
+        counter = Obj(tool=Obj(name="Laser Cutter"), name="Gas level")
+        expected = f"Warning threshold reached for {counter.tool.name} {counter.name} counter"
+        self.assertEqual(self.render("counter_threshold_reached_email", {"counter": counter}), expected)
+
+    def test_facility_rules_tutorial_email(self):
+        facility_name = "NanoFab"
+        self.assertEqual(
+            self.render("facility_rules_tutorial_email", {"facility_name": facility_name}),
+            f"{facility_name} rules tutorial",
+        )
+
+    def test_feedback_email(self):
+        user = Obj(_str="jsmith")
+        self.assertEqual(self.render("feedback_email", {"user": user}), f"Feedback from {user}")
+
+    def test_missed_reservation_email(self):
+        reservation = Obj(reservation_item=Obj(_str="Laser Cutter"))
+        expected = "Missed reservation for the " + str(reservation.reservation_item)
+        self.assertEqual(self.render("missed_reservation_email", {"reservation": reservation}), expected)
+
+    def test_new_task_email(self):
+        for safety_hazard in (False, True):
+            for force_shutdown in (False, True):
+                task = Obj(safety_hazard=safety_hazard, force_shutdown=force_shutdown, tool=Obj(name="SEM"))
+                expected = (
+                    ("SAFETY HAZARD: " if task.safety_hazard else "")
+                    + task.tool.name
+                    + (" shutdown" if task.force_shutdown else " problem")
+                )
+                actual = self.render("new_task_email", {"task": task})
+                self.assertEqual(actual, expected)
+
+    def test_out_of_time_reservation_email(self):
+        name = "Laser Cutter"
+        for has_start in (True, False):
+            reservation = Obj(start=has_start, reservation_item=Obj(_str=name))
+            expected = "Out of time for the " + name if has_start else "Out of allowed schedule for the " + name
+            actual = self.render("out_of_time_reservation_email", {"reservation": reservation})
+            self.assertEqual(actual, expected)
+
+    def test_recurring_charges_reminder_email(self):
+        recurring_charges_name = "Recurring charges"
+        reminder_days = 7
+        expected = f"{recurring_charges_name} will be charged in {reminder_days} day(s)"
+        actual = self.render(
+            "recurring_charges_reminder_email",
+            {"recurring_charges_name": recurring_charges_name, "reminder_days": reminder_days},
+        )
+        self.assertEqual(actual, expected)
+
+    def test_reorder_supplies_reminder_email(self):
+        item = Obj(name="Gloves")
+        self.assertEqual(
+            self.render("reorder_supplies_reminder_email", {"item": item}), f"Time to order more {item.name}"
+        )
+
+    def test_reservation_ending_reminder_email(self):
+        reservation = Obj(reservation_item=Obj(name="Laser Cutter"))
+        expected = reservation.reservation_item.name + " reservation ending soon"
+        self.assertEqual(self.render("reservation_ending_reminder_email", {"reservation": reservation}), expected)
+
+    def test_reservation_reminder_email(self):
+        item_name = "Laser Cutter"
+        reservation = Obj(reservation_item=Obj(name=item_name))
+        expected = item_name + " reservation reminder"
+        self.assertEqual(self.render("reservation_reminder_email", {"reservation": reservation}), expected)
+
+    def test_reservation_warning_email(self):
+        item_name = "Laser Cutter"
+        for fatal_error in (True, False):
+            reservation = Obj(reservation_item=Obj(name=item_name))
+            expected = item_name + (" reservation problem" if fatal_error else " reservation warning")
+            actual = self.render(
+                "reservation_warning_email", {"reservation": reservation, "fatal_error": fatal_error}
+            )
+            self.assertEqual(actual, expected)
+            # tasks.py's variant reaches the tool via reservation.tool rather than reservation.reservation_item;
+            # both must render the same subject through the one shared template.
+            reservation_tool_shaped = Obj(reservation_item=Obj(name=item_name), tool=Obj(name=item_name))
+            actual_tool_shaped = self.render(
+                "reservation_warning_email", {"reservation": reservation_tool_shaped, "fatal_error": fatal_error}
+            )
+            self.assertEqual(actual_tool_shaped, expected)
+
+    def test_safety_issue_email(self):
+        self.assertEqual(self.render("safety_issue_email", {}), "Safety issue")
+
+    def test_scheduled_outage_reminder_email(self):
+        outage = Obj(title="Power maintenance")
+        self.assertEqual(self.render("scheduled_outage_reminder_email", {"outage": outage}), f"{outage.title} reminder")
+
+    def test_staff_charge_reminder_email(self):
+        import datetime
+
+        from NEMO.utilities import format_datetime
+
+        start = datetime.datetime(2026, 9, 7, 14, 30)
+        staff_charge = Obj(start=start)
+        expected = "Active staff charge since " + format_datetime(staff_charge.start)
+        actual = self.render("staff_charge_reminder_email", {"staff_charge": staff_charge})
+        self.assertEqual(actual, expected)
+
+    def test_task_status_notification(self):
+        task = Obj(tool=Obj(_str="SEM"))
+        self.assertEqual(self.render("task_status_notification", {"task": task}), f"{task.tool} task notification")
+
+    def test_tool_qualification_expiration_email(self):
+        tool = Obj(name="SEM")
+        for remaining_days in (5, None):
+            if remaining_days:
+                subject_expiration = f" expires in {remaining_days} days!"
+            else:
+                subject_expiration = " has expired"
+            expected = f"Your {tool.name} qualification {subject_expiration}"
+            actual = self.render(
+                "tool_qualification_expiration_email", {"tool": tool, "remaining_days": remaining_days}
+            )
+            self.assertEqual(actual, expected)
+
+    def test_tool_required_unanswered_questions_email(self):
+        tool = Obj(name="SEM")
+        expected = f"Unanswered post‑usage questions after logoff from the {tool.name}"
+        self.assertEqual(self.render("tool_required_unanswered_questions_email", {"tool": tool}), expected)
+
+    def test_usage_reminder_email(self):
+        facility_name = "NanoFab"
+        self.assertEqual(self.render("usage_reminder_email", {"facility_name": facility_name}), f"{facility_name} usage")
+
+    def test_user_access_expiration_reminder_email(self):
+        import datetime
+
+        from NEMO.utilities import format_datetime
+
+        facility_name = "NanoFab"
+        remaining_days = 14
+        access_expiration = datetime.date(2026, 10, 1)
+        user = Obj(access_expiration=access_expiration)
+        expected = (
+            f"Your {facility_name} access expires in {remaining_days} days "
+            f"({format_datetime(user.access_expiration)})"
+        )
+        actual = self.render(
+            "user_access_expiration_reminder_email",
+            {"facility_name": facility_name, "remaining_days": remaining_days, "user": user},
+        )
+        self.assertEqual(actual, expected)
+
+    def test_reservation_created_and_cancelled_user_email(self):
+        reservation = Obj(reservation_item=Obj(_str="Laser Cutter"))
+        self.assertEqual(
+            self.render("reservation_created_user_email", {"reservation": reservation}),
+            "Reservation for the " + str(reservation.reservation_item),
+        )
+        self.assertEqual(
+            self.render("reservation_cancelled_user_email", {"reservation": reservation}),
+            "Cancelled Reservation for the " + str(reservation.reservation_item),
+        )
+
+    def test_weekend_access_email(self):
+        facility_name = "NanoFab"
+        sat, sun = "09/12/2026", "09/13/2026"
+        for access in (True, False):
+            expected = f"{'NO w' if not access else 'W'}eekend access for the {facility_name} {sat} - {sun}"
+            actual = self.render(
+                "weekend_access_email",
+                {"weekend_access": access, "facility_name": facility_name, "sat": sat, "sun": sun},
+            )
+            self.assertEqual(actual, expected)
+
+    def test_wait_list_notification_email(self):
+        tool = Obj(_str="Laser Cutter")
+        self.assertEqual(
+            self.render("wait_list_notification_email", {"tool": tool}), "Your turn for the " + str(tool)
+        )
+
+    def test_generic_email_intentionally_excluded(self):
+        self.assertNotIn("generic_email", SUBJECT_TEMPLATES)
+
+    def test_every_email_template_except_generic_has_a_subject_template(self):
+        from NEMO.views.customization import EMAIL_TEMPLATE_NAMES
+
+        expected_names = set(EMAIL_TEMPLATE_NAMES) - {"generic_email"}
+        self.assertEqual(set(SUBJECT_TEMPLATES.keys()), expected_names)
+
+
+class SubjectMigrationSafetyTestCase(NEMOTestCaseMixin, TestCase):
+    """The migration's forward/reverse functions must never touch a value an admin actually set."""
+
+    def test_forward_does_not_clobber_an_existing_customization(self):
+        from NEMO.models import Customization
+
+        # The real migration already ran while building the test database, so simulate "admin already
+        # customized this" by overwriting whatever value it left, rather than assuming no row exists yet.
+        Customization.objects.update_or_create(
+            name="feedback_email_subject", defaults={"value": "Admin's custom subject"}
+        )
+        migration_module.backfill_email_subjects(apps=_RealAppsShim(), schema_editor=None)
+        self.assertEqual(
+            Customization.objects.get(name="feedback_email_subject").value, "Admin's custom subject"
+        )
+
+    def test_forward_overwrites_a_row_still_holding_the_inert_placeholder(self):
+        # A row containing exactly "{{ default_subject }}" isn't a real customization  it's indistinguishable
+        # from "never customized" (it can end up saved this way if the shared form is ever submitted without
+        # editing that field), so the migration must still fill in the real subject for it.
+        from NEMO.models import Customization
+
+        Customization.objects.update_or_create(
+            name="feedback_email_subject", defaults={"value": "{{ default_subject }}"}
+        )
+        migration_module.backfill_email_subjects(apps=_RealAppsShim(), schema_editor=None)
+        self.assertEqual(
+            Customization.objects.get(name="feedback_email_subject").value,
+            SUBJECT_TEMPLATES["feedback_email"],
+        )
+
+    def test_reverse_does_not_delete_a_value_the_admin_changed_after_forward_ran(self):
+        from NEMO.models import Customization
+
+        migration_module.backfill_email_subjects(apps=_RealAppsShim(), schema_editor=None)
+        Customization.objects.filter(name="feedback_email_subject").update(value="Admin changed this afterward")
+        migration_module.remove_backfilled_email_subjects(apps=_RealAppsShim(), schema_editor=None)
+        self.assertEqual(
+            Customization.objects.get(name="feedback_email_subject").value, "Admin changed this afterward"
+        )
+
+    def test_reverse_removes_untouched_backfilled_rows(self):
+        from NEMO.models import Customization
+
+        migration_module.backfill_email_subjects(apps=_RealAppsShim(), schema_editor=None)
+        migration_module.remove_backfilled_email_subjects(apps=_RealAppsShim(), schema_editor=None)
+        self.assertFalse(Customization.objects.filter(name="feedback_email_subject").exists())
+
+
+class _RealAppsShim:
+    """Stands in for Django's historical `apps` registry, returning the real current model.
+
+    Safe here because the migration's forward/reverse functions only touch the Customization table's
+    unchanged (name, value) shape - there's no schema drift between the historical and current model to
+    worry about for this simple data migration.
+    """
+
+    @staticmethod
+    def get_model(app_label, model_name):
+        from django.apps import apps as real_apps
+
+        return real_apps.get_model(app_label, model_name)

--- a/NEMO/tests/test_send_email.py
+++ b/NEMO/tests/test_send_email.py
@@ -1,10 +1,14 @@
-from smtplib import SMTPConnectError, SMTPDataError, SMTPServerDisconnected, SMTPHeloError
+from smtplib import SMTPConnectError, SMTPDataError, SMTPException, SMTPServerDisconnected, SMTPHeloError
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.core import mail
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
 
+from NEMO.models import User
 from NEMO.tests.test_utilities import NEMOTestCaseMixin
 from NEMO.utilities import send_mail
+from NEMO.views.customization import TemplatesCustomization
 
 
 class TestSendMailRetries(NEMOTestCaseMixin, TestCase):
@@ -47,3 +51,101 @@ class TestSendMailRetries(NEMOTestCaseMixin, TestCase):
         result = send_mail(self.subject, self.content, self.from_email, self.to, fail_silently=True)
         self.assertEqual(result, 0)
         self.assertEqual(mock_send.call_count, 2)
+
+
+@patch("django.core.files.storage.FileSystemStorage.exists", return_value=True)
+@patch("django.core.files.storage.FileSystemStorage._open")
+class BroadcastEmailCcTestCase(NEMOTestCaseMixin, TestCase):
+    """A customized generic_email cc must be sent independently of the bcc chunks: exactly once, resilient to
+    a bcc chunk failure, and never duplicated for someone who's both the cc address and an audience member."""
+
+    def setUp(self):
+        self.sender = User.objects.create(
+            username="sender", first_name="S", last_name="S", email="sender@example.com", is_staff=True,
+            is_superuser=True,
+        )
+        self.login_as(self.sender)
+
+    def configure_mock_open(self, mock_open):
+        # A fresh ContentFile per test: it's a stream, and mock.return_value set once at decoration time
+        # (e.g. via @patch(..., return_value=...)) would be shared and exhausted across every test in the
+        # class after the first .read().
+        mock_open.return_value = ContentFile(b"<p>{{ contents }}</p>", name="generic_email.html")
+
+    def tearDown(self):
+        TemplatesCustomization.set("generic_email_cc", "")
+        super().tearDown()
+
+    def post_broadcast(self, subject="Test broadcast"):
+        return self.client.post(
+            "/send_broadcast_email/",
+            {
+                "audience": "user",
+                "no_type": "",
+                "title": "t",
+                "greeting": "g",
+                "contents": "c",
+                "color": "#5bc0de",
+                "subject": subject,
+                "send_to_inactive_users": "",
+                "send_to_expired_access_users": "",
+                "copy_me": "",
+            },
+        )
+
+    @override_settings(EMAIL_BROADCAST_BCC_CHUNK_SIZE=2)
+    def test_cc_sent_as_its_own_message_not_duplicated_per_chunk(self, mock_open, mock_exists):
+        self.configure_mock_open(mock_open)
+        for i in range(5):
+            User.objects.create(username=f"u{i}", first_name="F", last_name="L", email=f"u{i}@example.com")
+        TemplatesCustomization.set("generic_email_cc", "manager@example.com")
+
+        response = self.post_broadcast()
+
+        self.assertEqual(response.status_code, 302)
+        cc_emails = [m for m in mail.outbox if m.to == ["manager@example.com"]]
+        self.assertEqual(len(cc_emails), 1, "cc address should receive exactly one email, not one per chunk")
+        self.assertGreater(len(mail.outbox), 1, "sanity check: audience should have been split into multiple chunks")
+
+    @override_settings(EMAIL_BROADCAST_BCC_CHUNK_SIZE=2)
+    def test_cc_failure_does_not_block_the_bcc_chunks(self, mock_open, mock_exists):
+        self.configure_mock_open(mock_open)
+        for i in range(5):
+            User.objects.create(username=f"u{i}", first_name="F", last_name="L", email=f"u{i}@example.com")
+        TemplatesCustomization.set("generic_email_cc", "manager@example.com")
+
+        with patch("NEMO.views.email.send_mail") as mock_send:
+
+            def side_effect(*args, **kwargs):
+                if kwargs.get("to") == ["manager@example.com"]:
+                    raise SMTPException("simulated cc failure")
+                return 1
+
+            mock_send.side_effect = side_effect
+            response = self.post_broadcast()
+
+        # The broadcast overall still succeeds (redirect, not the hard-failure path) even though the
+        # independent cc send failed - only the bcc chunks' success determines the main outcome.
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(mock_send.call_count, 4)  # 1 attempted cc send + 3 bcc chunks
+
+    def test_cc_address_that_is_also_in_the_audience_gets_exactly_one_email(self, mock_open, mock_exists):
+        self.configure_mock_open(mock_open)
+        User.objects.create(username="u0", first_name="F", last_name="L", email="u0@example.com")
+        User.objects.create(username="u1", first_name="F", last_name="L", email="u1@example.com")
+        TemplatesCustomization.set("generic_email_cc", "u0@example.com")
+
+        self.post_broadcast()
+
+        all_recipients = [addr for m in mail.outbox for addr in (m.to + m.cc + m.bcc)]
+        self.assertEqual(all_recipients.count("u0@example.com"), 1)
+
+    def test_audience_entirely_overlapping_cc_does_not_crash(self, mock_open, mock_exists):
+        self.configure_mock_open(mock_open)
+        User.objects.create(username="onlyuser", first_name="F", last_name="L", email="only@example.com")
+        TemplatesCustomization.set("generic_email_cc", "only@example.com, sender@example.com")
+
+        response = self.post_broadcast()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)

--- a/NEMO/views/access_requests.py
+++ b/NEMO/views/access_requests.py
@@ -34,6 +34,7 @@ from NEMO.utilities import (
 from NEMO.views.customization import (
     UserRequestsCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 from NEMO.views.notifications import create_access_request_notification, delete_notification, get_notifications
 
@@ -219,33 +220,35 @@ def send_request_received_email(request, access_request: TemporaryPhysicalAccess
         )
         absolute_url = get_full_url(reverse("user_requests", kwargs={"tab": "access"}), request)
         color_type = "success" if status == "approved" else "danger" if status == "denied" else "info"
-        message = render_email_template(
-            access_request_notification_email,
-            {
-                "template_color": bootstrap_primary_color(color_type),
-                "access_request": access_request,
-                "status": status,
-                "access_requests_url": absolute_url,
-            },
-        )
         if status in ["received", "updated"]:
-            send_mail(
-                subject=f"Access request for the {access_request.physical_access_level.area} {status}",
-                content=message,
-                from_email=access_request.creator.email,
-                to=reviewer_emails,
-                cc=ccs,
-                email_category=EmailCategory.ACCESS_REQUESTS,
-            )
+            default_subject = f"Access request for the {access_request.physical_access_level.area} {status}"
+            default_from_email = access_request.creator.email
+            default_cc_emails = ", ".join(ccs)
+            to_addresses = reviewer_emails
         else:
-            send_mail(
-                subject=f"Your access request for the {access_request.physical_access_level.area} has been {status}",
-                content=message,
-                from_email=access_request.reviewer.email,
-                to=ccs,
-                cc=reviewer_emails,
-                email_category=EmailCategory.ACCESS_REQUESTS,
-            )
+            default_subject = f"Your access request for the {access_request.physical_access_level.area} has been {status}"
+            default_from_email = access_request.reviewer.email
+            default_cc_emails = ", ".join(reviewer_emails)
+            to_addresses = ccs
+        dictionary = {
+            "template_color": bootstrap_primary_color(color_type),
+            "access_request": access_request,
+            "status": status,
+            "access_requests_url": absolute_url,
+            "default_subject": default_subject,
+            "default_from_email": default_from_email,
+            "default_cc_emails": default_cc_emails,
+        }
+        message = render_email_template(access_request_notification_email, dictionary)
+        subject, from_email, cc = resolve_email_customization("access_request_notification_email", dictionary)
+        send_mail(
+            subject=subject,
+            content=message,
+            from_email=from_email,
+            to=to_addresses,
+            cc=cc,
+            email_category=EmailCategory.ACCESS_REQUESTS,
+        )
 
 
 @user_office_or_manager_required

--- a/NEMO/views/adjustment_requests.py
+++ b/NEMO/views/adjustment_requests.py
@@ -39,7 +39,12 @@ from NEMO.utilities import (
     send_mail,
     set_default_session_variable,
 )
-from NEMO.views.customization import AdjustmentRequestsCustomization, EmailsCustomization, get_media_file_contents
+from NEMO.views.customization import (
+    AdjustmentRequestsCustomization,
+    EmailsCustomization,
+    get_media_file_contents,
+    resolve_email_customization,
+)
 from NEMO.views.notifications import (
     create_adjustment_request_notification,
     create_request_message_notification,
@@ -394,12 +399,22 @@ def send_request_received_email(request, adjustment_request: AdjustmentRequest, 
         if enabled_for_creator:
             cc = adjustment_request.creator.get_emails(creator_notification)
         if status in ["received", "updated"]:
+            dictionary.update(
+                {
+                    "default_subject": f"Adjustment request {status}",
+                    "default_from_email": adjustment_request.creator.email,
+                    "default_cc_emails": ", ".join(cc or []),
+                }
+            )
+            subject, from_email, resolved_cc = resolve_email_customization(
+                "adjustment_request_notification_email", dictionary
+            )
             send_mail(
-                subject=f"Adjustment request {status}",
+                subject=subject,
                 content=message,
-                from_email=adjustment_request.creator.email,
+                from_email=from_email,
                 to=reviewer_emails,
-                cc=cc,
+                cc=resolved_cc,
                 email_category=EmailCategory.ADJUSTMENT_REQUESTS,
             )
         else:
@@ -408,12 +423,22 @@ def send_request_received_email(request, adjustment_request: AdjustmentRequest, 
             if enabled_for_creator:
                 to = adjustment_request.creator.get_emails(creator_notification)
                 cc = reviewer_emails
+            dictionary.update(
+                {
+                    "default_subject": f"Your adjustment request has been {status}",
+                    "default_from_email": adjustment_request.reviewer.email,
+                    "default_cc_emails": ", ".join(cc or []),
+                }
+            )
+            subject, from_email, resolved_cc = resolve_email_customization(
+                "adjustment_request_notification_email", dictionary
+            )
             send_mail(
-                subject=f"Your adjustment request has been {status}",
+                subject=subject,
                 content=message,
-                from_email=adjustment_request.reviewer.email,
+                from_email=from_email,
                 to=to,
-                cc=cc,
+                cc=resolved_cc,
                 email_category=EmailCategory.ADJUSTMENT_REQUESTS,
             )
 
@@ -422,13 +447,23 @@ def send_request_received_email(request, adjustment_request: AdjustmentRequest, 
         if not adjustment_request.applied and adjustment_request.status == RequestStatus.APPROVED:
             dictionary["manager_note"] = adjustment_request.manager_note
             dictionary["user_office"] = True
+            dictionary.update(
+                {
+                    "default_subject": f"{adjustment_request.creator.get_name()}'s adjustment request has been {status}",
+                    "default_from_email": adjustment_request.reviewer.email,
+                    "default_cc_emails": ", ".join(reviewer_emails),
+                }
+            )
             message = render_email_template(adjustment_request_notification_email, dictionary)
+            subject, from_email, resolved_cc = resolve_email_customization(
+                "adjustment_request_notification_email", dictionary
+            )
             send_mail(
-                subject=f"{adjustment_request.creator.get_name()}'s adjustment request has been {status}",
+                subject=subject,
                 content=message,
-                from_email=adjustment_request.reviewer.email,
+                from_email=from_email,
                 to=[user_office_email],
-                cc=reviewer_emails,
+                cc=resolved_cc,
                 email_category=EmailCategory.ADJUSTMENT_REQUESTS,
             )
 

--- a/NEMO/views/calendar.py
+++ b/NEMO/views/calendar.py
@@ -56,6 +56,7 @@ from NEMO.views.customization import (
     EmailsCustomization,
     ToolCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 
 calendar_logger = getLogger(__name__)
@@ -1068,8 +1069,12 @@ def cancel_the_reservation(
                     "reservation": reservation,
                     "reason": reason,
                     "template_color": bootstrap_primary_color("info"),
+                    "default_subject": "Your reservation was cancelled",
+                    "default_from_email": user_cancelling_reservation.email,
+                    "default_cc_emails": "",
                 }
                 cancellation_email = render_email_template(email_contents, dictionary, request)
+                subject, from_email, cc = resolve_email_customization("cancellation_email", dictionary)
                 recipients = reservation.user.get_emails(
                     reservation.user.get_preferences().email_send_reservation_emails
                 )
@@ -1088,18 +1093,20 @@ def cancel_the_reservation(
                         location=location,
                     )
                     send_mail(
-                        subject="Your reservation was cancelled",
+                        subject=subject,
                         content=cancellation_email,
-                        from_email=user_cancelling_reservation.email,
+                        from_email=from_email,
                         to=recipients,
+                        cc=cc,
                         attachments=[attachment],
                     )
                 else:
                     send_mail(
-                        subject="Your reservation was cancelled",
+                        subject=subject,
                         content=cancellation_email,
-                        from_email=user_cancelling_reservation.email,
+                        from_email=from_email,
                         to=recipients,
+                        cc=cc,
                     )
 
         else:
@@ -1135,10 +1142,16 @@ def send_user_created_reservation_notification(reservation: Reservation):
     if reservation.area:
         recipients.extend(reservation.area.reservation_email_list())
     if recipients:
-        subject = f"Reservation for the " + str(reservation.reservation_item)
         message = get_media_file_contents("reservation_created_user_email.html")
-        message = render_email_template(message, {"reservation": reservation})
         user_office_email = EmailsCustomization.get("user_office_email_address")
+        dictionary = {
+            "reservation": reservation,
+            "default_subject": "Reservation for the " + str(reservation.reservation_item),
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        message = render_email_template(message, dictionary)
+        subject, from_email, cc = resolve_email_customization("reservation_created_user_email", dictionary)
         # We don't need to check for existence of reservation_created_user_email because we are attaching the ics reservation and sending the email regardless (message will be blank)
         if user_office_email:
             event_name = reservation.title or f"{reservation.reservation_item.name} Reservation"
@@ -1153,7 +1166,12 @@ def send_user_created_reservation_notification(reservation: Reservation):
                 location=location,
             )
             send_mail(
-                subject=subject, content=message, from_email=user_office_email, to=recipients, attachments=[attachment]
+                subject=subject,
+                content=message,
+                from_email=from_email,
+                to=recipients,
+                cc=cc,
+                attachments=[attachment],
             )
         else:
             calendar_logger.error(
@@ -1171,10 +1189,16 @@ def send_user_cancelled_reservation_notification(reservation: Reservation):
     if reservation.area:
         recipients.extend(reservation.area.reservation_email_list())
     if recipients:
-        subject = f"Cancelled Reservation for the " + str(reservation.reservation_item)
         message = get_media_file_contents("reservation_cancelled_user_email.html")
-        message = render_email_template(message, {"reservation": reservation})
         user_office_email = EmailsCustomization.get("user_office_email_address")
+        dictionary = {
+            "reservation": reservation,
+            "default_subject": "Cancelled Reservation for the " + str(reservation.reservation_item),
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        message = render_email_template(message, dictionary)
+        subject, from_email, cc = resolve_email_customization("reservation_cancelled_user_email", dictionary)
         # We don't need to check for existence of reservation_cancelled_user_email because we are attaching the ics reservation and sending the email regardless (message will be blank)
         if user_office_email:
             event_name = reservation.title or f"{reservation.reservation_item.name} Reservation"
@@ -1189,7 +1213,12 @@ def send_user_cancelled_reservation_notification(reservation: Reservation):
                 location=location,
             )
             send_mail(
-                subject=subject, content=message, from_email=user_office_email, to=recipients, attachments=[attachment]
+                subject=subject,
+                content=message,
+                from_email=from_email,
+                to=recipients,
+                cc=cc,
+                attachments=[attachment],
             )
         else:
             calendar_logger.error(

--- a/NEMO/views/consumables.py
+++ b/NEMO/views/consumables.py
@@ -31,6 +31,7 @@ from NEMO.views.customization import (
     EmailsCustomization,
     RecurringChargesCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 from NEMO.views.pagination import SortedPaginator
 
@@ -354,12 +355,19 @@ def send_reorder_supply_reminder_email(consumable: Consumable):
     user_office_email = EmailsCustomization.get("user_office_email_address")
     message = get_media_file_contents("reorder_supplies_reminder_email.html")
     if user_office_email and message:
-        subject = f"Time to order more {consumable.name}"
-        rendered_message = render_email_template(message, {"item": consumable})
+        dictionary = {
+            "item": consumable,
+            "default_subject": f"Time to order more {consumable.name}",
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        rendered_message = render_email_template(message, dictionary)
+        subject, from_email, cc = resolve_email_customization("reorder_supplies_reminder_email", dictionary)
         send_mail(
             subject=subject,
             content=rendered_message,
-            from_email=user_office_email,
+            from_email=from_email,
             to=[consumable.reminder_email],
+            cc=cc,
             email_category=EmailCategory.SYSTEM,
         )

--- a/NEMO/views/customization.py
+++ b/NEMO/views/customization.py
@@ -21,6 +21,7 @@ from django.core.validators import (
 )
 from django.http import HttpResponseNotFound
 from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.template import Context, Template, TemplateDoesNotExist
 from django.template.loader import get_template
 from django.utils import timezone
@@ -49,6 +50,7 @@ from NEMO.utilities import (
     date_input_format,
     datetime_input_format,
     quiet_int,
+    render_email_template,
 )
 
 customization_logger = getLogger(__name__)
@@ -128,7 +130,10 @@ class CustomizationBase(ABC):
                     pass
 
     def context(self) -> Dict:
-        files_dict = {name: get_media_file_contents(name + extension) for name, extension in type(self).files}
+        files_dict = {
+            name: get_media_file_contents(name + media_file_extension(extension))
+            for name, extension in type(self).files
+        }
         variables_dict = {name: type(self).get(name) for name in type(self).variables}
         return {"customization": self, **variables_dict, **files_dict}
 
@@ -142,7 +147,7 @@ class CustomizationBase(ABC):
                     item = (name, extension)
                     break
             if item:
-                store_media_file(request.FILES.get(element, ""), item[0] + item[1])
+                store_media_file(request.FILES.get(element, ""), item[0] + media_file_extension(item[1]))
         else:
             # We are saving key values here
             for key in type(self).variables.keys():
@@ -864,41 +869,111 @@ class TrainingCustomization(CustomizationBase):
 @customization(key="templates", title="File & email templates")
 class TemplatesCustomization(CustomizationBase):
     variables = {}
+    # ".email" identifies an entry as one that's actually sent as an email (as opposed to login_banner/
+    # authorization_failed/safety_introduction/facility_rules_tutorial/jumbotron_watermark, which are rendered as
+    # page content, not emails). The file is still stored and served as plain ".html"; see media_file_extension().
     files = [
         ("login_banner", ".html"),
         ("authorization_failed", ".html"),
         ("safety_introduction", ".html"),
         ("facility_rules_tutorial", ".html"),
         ("jumbotron_watermark", ".png"),
-        ("access_request_notification_email", ".html"),
-        ("adjustment_request_notification_email", ".html"),
-        ("cancellation_email", ".html"),
-        ("counter_threshold_reached_email", ".html"),
-        ("feedback_email", ".html"),
-        ("generic_email", ".html"),
-        ("missed_reservation_email", ".html"),
-        ("facility_rules_tutorial_email", ".html"),
-        ("new_task_email", ".html"),
-        ("out_of_time_reservation_email", ".html"),
-        ("reorder_supplies_reminder_email", ".html"),
-        ("reservation_ending_reminder_email", ".html"),
-        ("reservation_reminder_email", ".html"),
-        ("reservation_warning_email", ".html"),
-        ("safety_issue_email", ".html"),
-        ("scheduled_outage_reminder_email", ".html"),
-        ("staff_charge_reminder_email", ".html"),
-        ("task_status_notification", ".html"),
-        ("tool_qualification_expiration_email", ".html"),
-        ("unauthorized_tool_access_email", ".html"),
-        ("usage_reminder_email", ".html"),
-        ("user_access_expiration_reminder_email", ".html"),
-        ("reservation_created_user_email", ".html"),
-        ("reservation_cancelled_user_email", ".html"),
-        ("weekend_access_email", ".html"),
-        ("recurring_charges_reminder_email", ".html"),
-        ("wait_list_notification_email", ".html"),
-        ("tool_required_unanswered_questions_email", ".html"),
+        ("access_request_notification_email", ".email"),
+        ("adjustment_request_notification_email", ".email"),
+        ("cancellation_email", ".email"),
+        ("counter_threshold_reached_email", ".email"),
+        ("feedback_email", ".email"),
+        ("generic_email", ".email"),
+        ("missed_reservation_email", ".email"),
+        ("facility_rules_tutorial_email", ".email"),
+        ("new_task_email", ".email"),
+        ("out_of_time_reservation_email", ".email"),
+        ("reorder_supplies_reminder_email", ".email"),
+        ("reservation_ending_reminder_email", ".email"),
+        ("reservation_reminder_email", ".email"),
+        ("reservation_warning_email", ".email"),
+        ("safety_issue_email", ".email"),
+        ("scheduled_outage_reminder_email", ".email"),
+        ("staff_charge_reminder_email", ".email"),
+        ("task_status_notification", ".email"),
+        ("tool_qualification_expiration_email", ".email"),
+        ("unauthorized_tool_access_email", ".email"),
+        ("usage_reminder_email", ".email"),
+        ("user_access_expiration_reminder_email", ".email"),
+        ("reservation_created_user_email", ".email"),
+        ("reservation_cancelled_user_email", ".email"),
+        ("weekend_access_email", ".email"),
+        ("recurring_charges_reminder_email", ".email"),
+        ("wait_list_notification_email", ".email"),
+        ("tool_required_unanswered_questions_email", ".email"),
     ]
+
+    def __init__(self, *args, **kwargs):
+        # Every email template gets a customizable subject/from/cc, each a Django template string rendered
+        # with the same context as the email body. The defaults simply pass through whatever the call site
+        # already computed as its "default_subject"/"default_from_email"/"default_cc_emails" context variables,
+        # so behavior is unchanged until an admin actually overrides one of these fields.
+        for email_template_name, extension in type(self).files:
+            if extension != ".email":
+                continue
+            self.__class__.variables[f"{email_template_name}_subject"] = "{{ default_subject }}"
+            self.__class__.variables[f"{email_template_name}_from"] = "{{ default_from_email }}"
+            self.__class__.variables[f"{email_template_name}_cc"] = "{{ default_cc_emails }}"
+        super().__init__(*args, **kwargs)
+
+    def save(self, request, element=None) -> Dict[str, Dict[str, str]]:
+        # An element ending in "_fields" (as opposed to a plain email template name, which means "save this
+        # template's uploaded file") means "save only this one email template's subject/from/cc", used by the
+        # per-template save button so it doesn't touch any other template's fields.
+        if element and element.endswith(EMAIL_TEMPLATE_FIELDS_ELEMENT_SUFFIX):
+            template_name = element[: -len(EMAIL_TEMPLATE_FIELDS_ELEMENT_SUFFIX)]
+            is_email_template = any(
+                name == template_name and extension == ".email" for name, extension in type(self).files
+            )
+            if is_email_template:
+                errors = {}
+                for suffix in ("subject", "from", "cc"):
+                    key = f"{template_name}_{suffix}"
+                    new_value = request.POST.get(key, "")
+                    try:
+                        self.validate(key, new_value)
+                        type(self).set(key, new_value)
+                    except (ValidationError, InvalidCustomizationException) as e:
+                        errors[key] = {"error": str(e.message or e.msg), "value": new_value}
+                return errors
+        return super().save(request, element)
+
+
+# Names of the TemplatesCustomization.files entries marked as emails (extension ".email"), derived from the
+# files list itself so there's a single source of truth for "which templates are emails".
+EMAIL_TEMPLATE_NAMES = [name for name, extension in TemplatesCustomization.files if extension == ".email"]
+
+# Suffix used to build a distinct "element" identifier for the per-template subject/from/cc save button, so it
+# doesn't collide with the plain template name already used by that same template's file-upload form.
+EMAIL_TEMPLATE_FIELDS_ELEMENT_SUFFIX = "_fields"
+
+
+def resolve_email_customization(template_name: str, dictionary: dict, request=None):
+    """
+    Resolves the customizable subject, from address and cc addresses for the given email template
+    (one of TemplatesCustomization.EMAIL_TEMPLATE_NAMES), each rendered as a Django template string
+    using the same context dictionary as the email body.
+
+    Callers should set "default_subject", "default_from_email" and "default_cc_emails" (a comma-separated
+    string, may be blank) in `dictionary` before calling this, since the customization defaults are simply
+    "{{ default_subject }}", "{{ default_from_email }}" and "{{ default_cc_emails }}" - i.e. until an admin
+    overrides one of these fields, behavior is unchanged from whatever the caller would have used directly.
+
+    Returns a (subject, from_email, cc_list) tuple, where cc_list is a list of stripped, non-empty addresses.
+    """
+    subject_template = TemplatesCustomization.get(f"{template_name}_subject")
+    from_template = TemplatesCustomization.get(f"{template_name}_from")
+    cc_template = TemplatesCustomization.get(f"{template_name}_cc")
+    subject = render_email_template(subject_template, dictionary, request).strip()
+    from_email = render_email_template(from_template, dictionary, request).strip()
+    cc_rendered = render_email_template(cc_template, dictionary, request).strip()
+    cc = [address.strip() for address in cc_rendered.split(",") if address.strip()]
+    return subject, from_email, cc
 
 
 @customization(key="rates", title="Rates")
@@ -935,6 +1010,16 @@ def store_media_file(content, file_name):
     default_storage.delete(file_name)
     if content:
         default_storage.save(file_name, content)
+
+
+def media_file_extension(extension: str) -> str:
+    """
+    Translates a CustomizationBase.files "extension" into the extension actually used on disk. ".email" is a
+    marker extension used in `files` lists to identify entries that are sent as emails (as opposed to page
+    fragments or other assets); the underlying stored file is still plain ".html" since the content itself is
+    just an HTML template either way.
+    """
+    return ".html" if extension == ".email" else extension
 
 
 # This method should not be used anymore. Instead, use XCustomization.get(name)
@@ -991,5 +1076,18 @@ def customize(request, key, element=None):
             request, "customizations/customizations.html", {"errors": errors, **customization_instance.context()}
         )
     else:
+        template_name = (
+            element[: -len(EMAIL_TEMPLATE_FIELDS_ELEMENT_SUFFIX)]
+            if element and element.endswith(EMAIL_TEMPLATE_FIELDS_ELEMENT_SUFFIX)
+            else None
+        )
+        if template_name and template_name in EMAIL_TEMPLATE_NAMES:
+            # Scoped per-template save: redirect back anchored to that template's own panel, where an inline
+            # banner (not the generic top-of-page one) confirms just that template's fields were saved.
+            return redirect(f"{reverse('customization', args=[key])}?saved={template_name}#{template_name}_id")
+        if element and any(name == element for name, _ in getattr(customization_instance, "files", [])):
+            # A file/textarea upload: same idea, but a distinct query param so it can never be confused with
+            # (or accidentally shown alongside) the subject/from/cc banner above for the same element name.
+            return redirect(f"{reverse('customization', args=[key])}?file_saved={element}#{element}_id")
         messages.success(request, f"{customization_instance.title} settings saved successfully")
         return redirect("customization", key)

--- a/NEMO/views/email.py
+++ b/NEMO/views/email.py
@@ -34,6 +34,7 @@ from NEMO.views.customization import (
     ApplicationCustomization,
     ToolControlCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 
 logger = getLogger(__name__)
@@ -269,9 +270,9 @@ def send_broadcast_email(request):
     if not users:
         dictionary = {"error": "The audience you specified is empty. You must send the email to at least one person."}
         return render(request, "email/compose_email.html", dictionary)
-    subject = form.cleaned_data["subject"]
+    default_subject = form.cleaned_data["subject"]
     if topic:
-        subject = f"[{topic}] " + subject
+        default_subject = f"[{topic}] " + default_subject
     users = [email for user in users for email in user.get_emails(user.get_preferences().email_send_broadcast_emails)]
     sender: User = request.user
     if form.cleaned_data["copy_me"]:
@@ -280,21 +281,55 @@ def send_broadcast_email(request):
         create_email_attachment(attachment.file, attachment.name)
         for attachment in request.FILES.getlist("attachments", [])
     ]
-    try:
-        users_set = set(users)
-        chunk_size = quiet_int(getattr(settings, "EMAIL_BROADCAST_BCC_CHUNK_SIZE", len(users_set)), len(users_set))
-        for users_chunk in split_into_chunks(users_set, chunk_size):
+    dictionary.update(
+        {
+            "default_subject": default_subject,
+            "default_from_email": sender.email,
+            "default_cc_emails": "",
+        }
+    )
+    subject, from_email, cc = resolve_email_customization("generic_email", dictionary)
+    site_title = ApplicationCustomization.get("site_title")
+
+    # Sent as its own independent message (not piggybacked onto a bcc chunk) so a customized cc address gets
+    # exactly one copy of the broadcast, and its delivery doesn't depend on - or get blocked by a failure in -
+    # any particular bcc chunk.
+    cc_error = None
+    if cc:
+        try:
             send_mail(
                 subject=subject,
                 content=content,
-                from_email=sender.email,
-                bcc=users_chunk,
+                from_email=from_email,
+                to=cc,
                 attachments=attachments,
                 email_category=EmailCategory.BROADCAST_EMAIL,
                 fail_silently=False,
             )
+        except SMTPException as error:
+            cc_error = str(error)
+            logger.exception(f"Unable to send the broadcast email cc copy to {', '.join(cc)}: {cc_error}")
+
+    try:
+        # Excludes any address that's also getting the dedicated cc copy above, so someone who happens to be
+        # both the configured cc and a member of the broadcast audience (e.g. a facility manager who is cc'ed
+        # on every broadcast but is also a regular user) doesn't receive the same broadcast twice.
+        users_set = set(users) - set(cc)
+        if users_set:
+            chunk_size = quiet_int(
+                getattr(settings, "EMAIL_BROADCAST_BCC_CHUNK_SIZE", len(users_set)), len(users_set)
+            )
+            for users_chunk in split_into_chunks(users_set, chunk_size):
+                send_mail(
+                    subject=subject,
+                    content=content,
+                    from_email=from_email,
+                    bcc=users_chunk,
+                    attachments=attachments,
+                    email_category=EmailCategory.BROADCAST_EMAIL,
+                    fail_silently=False,
+                )
     except SMTPException as error:
-        site_title = ApplicationCustomization.get("site_title")
         error_message = (
             f"{site_title} was unable to send the email through the email server. The error message that was received is: "
             + str(error)
@@ -302,7 +337,17 @@ def send_broadcast_email(request):
         logger.exception(error_message)
         messages.error(request, message=error_message)
         return redirect("email_broadcast")
-    messages.success(request, message="Your email was sent successfully")
+
+    if cc_error:
+        messages.warning(
+            request,
+            message=(
+                f"Your email was sent, but {site_title} was unable to send the cc copy to {', '.join(cc)}. "
+                f"The error message that was received is: {cc_error}"
+            ),
+        )
+    else:
+        messages.success(request, message="Your email was sent successfully")
     return redirect("email_broadcast")
 
 

--- a/NEMO/views/feedback.py
+++ b/NEMO/views/feedback.py
@@ -4,7 +4,7 @@ from django.views.decorators.http import require_http_methods
 
 from NEMO.constants import FEEDBACK_MAXIMUM_LENGTH
 from NEMO.utilities import EmailCategory, parse_parameter_string, render_email_template, send_mail
-from NEMO.views.customization import EmailsCustomization, get_media_file_contents
+from NEMO.views.customization import EmailsCustomization, get_media_file_contents, resolve_email_customization
 
 
 @login_required
@@ -23,14 +23,19 @@ def feedback(request):
     dictionary = {
         "contents": contents,
         "user": request.user,
+        "default_subject": "Feedback from " + str(request.user),
+        "default_from_email": request.user.email,
+        "default_cc_emails": "",
     }
 
     email = render_email_template(email_contents, dictionary, request)
+    subject, from_email, cc = resolve_email_customization("feedback_email", dictionary)
     send_mail(
-        subject="Feedback from " + str(request.user),
+        subject=subject,
         content=email,
-        from_email=request.user.email,
+        from_email=from_email,
         to=[recipient],
+        cc=cc,
         email_category=EmailCategory.FEEDBACK,
     )
     dictionary = {

--- a/NEMO/views/safety.py
+++ b/NEMO/views/safety.py
@@ -19,7 +19,12 @@ from NEMO.utilities import (
     render_email_template,
     send_mail,
 )
-from NEMO.views.customization import EmailsCustomization, SafetyCustomization, get_media_file_contents
+from NEMO.views.customization import (
+    EmailsCustomization,
+    SafetyCustomization,
+    get_media_file_contents,
+    resolve_email_customization,
+)
 from NEMO.views.notifications import create_safety_notification, delete_notification, get_notifications
 
 
@@ -125,15 +130,22 @@ def send_safety_email_notification(request, issue):
     recipient = EmailsCustomization.get("safety_email_address")
     message = get_media_file_contents("safety_issue_email.html")
     if recipient and message:
-        subject = "Safety issue"
-        dictionary = {"issue": issue, "issue_absolute_url": get_full_url(issue.get_absolute_url(), request)}
-        rendered_message = render_email_template(message, dictionary, request)
         from_email = issue.reporter.email if issue.reporter else recipient
+        dictionary = {
+            "issue": issue,
+            "issue_absolute_url": get_full_url(issue.get_absolute_url(), request),
+            "default_subject": "Safety issue",
+            "default_from_email": from_email,
+            "default_cc_emails": "",
+        }
+        rendered_message = render_email_template(message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("safety_issue_email", dictionary)
         send_mail(
             subject=subject,
             content=rendered_message,
             from_email=from_email,
             to=[recipient],
+            cc=cc,
             email_category=EmailCategory.SAFETY,
         )
 

--- a/NEMO/views/tasks.py
+++ b/NEMO/views/tasks.py
@@ -42,6 +42,7 @@ from NEMO.views.customization import (
     RemoteWorkCustomization,
     ToolCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 from NEMO.views.safety import send_safety_email_notification
 from NEMO.views.tool_control import determine_tool_status
@@ -142,6 +143,11 @@ def send_new_task_emails(request, task: Task, user, task_images: List[TaskImages
         attachments = [create_email_attachment(task_image.image, task_image.image.name) for task_image in task_images]
     # Email the appropriate staff that a new task has been created:
     if message:
+        default_subject = (
+            ("SAFETY HAZARD: " if task.safety_hazard else "")
+            + task.tool.name
+            + (" shutdown" if task.force_shutdown else " problem")
+        )
         dictionary = {
             "template_color": (
                 bootstrap_primary_color("danger") if task.force_shutdown else bootstrap_primary_color("warning")
@@ -150,13 +156,12 @@ def send_new_task_emails(request, task: Task, user, task_images: List[TaskImages
             "task": task,
             "tool": task.tool,
             "tool_control_absolute_url": get_full_url(task.tool.get_absolute_url(), request),
+            "default_subject": default_subject,
+            "default_from_email": user.email,
+            "default_cc_emails": "",
         }
-        subject = (
-            ("SAFETY HAZARD: " if task.safety_hazard else "")
-            + task.tool.name
-            + (" shutdown" if task.force_shutdown else " problem")
-        )
         message = render_email_template(message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("new_task_email", dictionary)
         tos, bcc = get_task_email_recipients(task, new=True)
         if ToolCustomization.get_bool("tool_problem_send_to_all_qualified_users"):
             for qualified_user in task.tool.user_set.filter(is_active=True).select_related("preferences"):
@@ -169,8 +174,9 @@ def send_new_task_emails(request, task: Task, user, task_images: List[TaskImages
         send_mail(
             subject=subject,
             content=message,
-            from_email=user.email,
+            from_email=from_email,
             to=tos,
+            cc=cc,
             bcc=bcc,
             attachments=attachments,
             email_category=EmailCategory.TASKS,
@@ -192,33 +198,23 @@ def send_new_task_emails(request, task: Task, user, task_images: List[TaskImages
                 unique_users.add(r.user_id)
                 unique_user_reservations.append(r)
         for reservation in unique_user_reservations:
-            if not task.tool.operational:
-                subject = reservation.tool.name + " reservation problem"
-                rendered_message = render_email_template(
-                    message,
-                    {
-                        "reservation": reservation,
-                        "template_color": bootstrap_primary_color("danger"),
-                        "fatal_error": True,
-                    },
-                    request,
-                )
-            else:
-                subject = reservation.tool.name + " reservation warning"
-                rendered_message = render_email_template(
-                    message,
-                    {
-                        "reservation": reservation,
-                        "template_color": bootstrap_primary_color("warning"),
-                        "fatal_error": False,
-                    },
-                    request,
-                )
+            fatal_error = not task.tool.operational
+            reservation_dictionary = {
+                "reservation": reservation,
+                "template_color": bootstrap_primary_color("danger" if fatal_error else "warning"),
+                "fatal_error": fatal_error,
+                "default_subject": reservation.tool.name + (" reservation problem" if fatal_error else " reservation warning"),
+                "default_from_email": user_office_email,
+                "default_cc_emails": "",
+            }
+            rendered_message = render_email_template(message, reservation_dictionary, request)
+            subject, from_email, cc = resolve_email_customization("reservation_warning_email", reservation_dictionary)
             email_notification = reservation.user.get_preferences().email_send_reservation_emails
             reservation.user.email_user(
                 subject=subject,
                 message=rendered_message,
-                from_email=user_office_email,
+                from_email=from_email,
+                cc=cc,
                 email_category=EmailCategory.TASKS,
                 email_notification=email_notification,
             )
@@ -400,9 +396,12 @@ def set_task_status(request, task, status_name, user):
             "notification_message": status.notification_message,
             "task": task,
             "tool_control_absolute_url": get_full_url(task.tool.get_absolute_url(), request),
+            "default_subject": f"{task.tool} task notification",
+            "default_from_email": user.email,
+            "default_cc_emails": "",
         }
-        subject = f"{task.tool} task notification"
         message = render_email_template(message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("task_status_notification", dictionary)
         # Add primary owner if applicable
         recipient_users: List[User] = [task.tool.primary_owner] if status.notify_primary_tool_owner else []
         if status.notify_backup_tool_owners:
@@ -421,7 +420,12 @@ def set_task_status(request, task, status_name, user):
             recipients.append(task.tool.notification_email_address)
         recipients.append(status.custom_notification_email_address)
         send_mail(
-            subject=subject, content=message, from_email=user.email, to=recipients, email_category=EmailCategory.TASKS
+            subject=subject,
+            content=message,
+            from_email=from_email,
+            to=recipients,
+            cc=cc,
+            email_category=EmailCategory.TASKS,
         )
 
 

--- a/NEMO/views/timed_services.py
+++ b/NEMO/views/timed_services.py
@@ -60,6 +60,7 @@ from NEMO.views.customization import (
     UserCustomization,
     UserRequestsCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 from NEMO.views.qualifications import disqualify
 
@@ -168,16 +169,23 @@ def send_missed_reservation_notification(reservation, request=None):
     user_office_email = EmailsCustomization.get("user_office_email_address")
     abuse_email = EmailsCustomization.get("abuse_email_address")
     if message and user_office_email:
-        subject = "Missed reservation for the " + str(reservation.reservation_item)
-        message = render_email_template(message, {"reservation": reservation}, request)
+        dictionary = {
+            "reservation": reservation,
+            "default_subject": "Missed reservation for the " + str(reservation.reservation_item),
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        message = render_email_template(message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("missed_reservation_email", dictionary)
         recipients = reservation.user.get_emails(reservation.user.get_preferences().email_send_reservation_emails)
         recipients.append(abuse_email)
         recipients.append(user_office_email)
         send_mail(
             subject=subject,
             content=message,
-            from_email=user_office_email,
+            from_email=from_email,
             to=recipients,
+            cc=cc,
             email_category=EmailCategory.TIMED_SERVICES,
         )
     else:
@@ -361,16 +369,23 @@ def get_reservation_end(reservation):
 def notify_next_user_in_wait_list(entry, time_to_expiration):
     message = get_media_file_contents("wait_list_notification_email.html")
     if message:
-        subject = "Your turn for the " + str(entry.tool)
-        message = render_email_template(
-            message, {"user": entry.user, "tool": entry.tool, "time_to_expiration": time_to_expiration}
-        )
+        dictionary = {
+            "user": entry.user,
+            "tool": entry.tool,
+            "time_to_expiration": time_to_expiration,
+            "default_subject": "Your turn for the " + str(entry.tool),
+            "default_from_email": get_email_from_settings(),
+            "default_cc_emails": "",
+        }
+        message = render_email_template(message, dictionary)
+        subject, from_email, cc = resolve_email_customization("wait_list_notification_email", dictionary)
         recipients = entry.user.get_emails(entry.user.get_preferences().email_send_wait_list_notification_emails)
         send_mail(
             subject=subject,
             content=message,
-            from_email=get_email_from_settings(),
+            from_email=from_email,
             to=recipients,
+            cc=cc,
             email_category=EmailCategory.TIMED_SERVICES,
         )
     else:
@@ -459,8 +474,16 @@ def send_out_of_time_reservation_notification(reservation: Reservation, request=
     user_office_email = EmailsCustomization.get("user_office_email_address")
     if message and user_office_email:
         name = str(reservation.area.name)
-        subject = "Out of time for the " + name if reservation.start else "Out of allowed schedule for the " + name
-        message = render_email_template(message, {"reservation": reservation}, request)
+        dictionary = {
+            "reservation": reservation,
+            "default_subject": (
+                "Out of time for the " + name if reservation.start else "Out of allowed schedule for the " + name
+            ),
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        message = render_email_template(message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("out_of_time_reservation_email", dictionary)
         recipients = reservation.user.get_emails(
             reservation.user.get_preferences().email_send_reservation_ending_reminders
         )
@@ -468,8 +491,9 @@ def send_out_of_time_reservation_notification(reservation: Reservation, request=
         send_mail(
             subject=subject,
             content=message,
-            from_email=user_office_email,
+            from_email=from_email,
             to=recipients,
+            cc=cc,
             email_category=EmailCategory.TIMED_SERVICES,
         )
     else:
@@ -526,15 +550,20 @@ def send_email_reservation_ending_reminders(request=None):
         )
         if starting_reservation.exists():
             continue
-        subject = reservation.reservation_item.name + " reservation ending soon"
-        rendered_message = render_email_template(
-            reservation_ending_reminder_message, {"reservation": reservation}, request
-        )
+        dictionary = {
+            "reservation": reservation,
+            "default_subject": reservation.reservation_item.name + " reservation ending soon",
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        rendered_message = render_email_template(reservation_ending_reminder_message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("reservation_ending_reminder_email", dictionary)
         email_notification = reservation.user.get_preferences().email_send_reservation_ending_reminders
         reservation.user.email_user(
             subject=subject,
             message=rendered_message,
-            from_email=user_office_email,
+            from_email=from_email,
+            cc=cc,
             email_category=EmailCategory.TIMED_SERVICES,
             email_notification=email_notification,
         )
@@ -594,20 +623,28 @@ def send_email_usage_reminders(projects_to_exclude=None, request=None):
     message = get_media_file_contents("usage_reminder_email.html")
     facility_name = ApplicationCustomization.get("facility_name")
     if message:
-        subject = f"{facility_name} usage"
+        default_subject = f"{facility_name} usage"
         for value in aggregate.values():
             user: User = value["user"]
             resources_in_use = value["resources_in_use"]
             # for backwards compatibility, add it to the user object (that's how it was defined and used in the template)
             user.resources_in_use = resources_in_use
-            rendered_message = render_email_template(
-                message, {"user": user, "resources_in_use": resources_in_use}, request
-            )
+            dictionary = {
+                "user": user,
+                "resources_in_use": resources_in_use,
+                "facility_name": facility_name,
+                "default_subject": default_subject,
+                "default_from_email": user_office_email,
+                "default_cc_emails": "",
+            }
+            rendered_message = render_email_template(message, dictionary, request)
+            subject, from_email, cc = resolve_email_customization("usage_reminder_email", dictionary)
             email_notification = user.get_preferences().email_send_usage_reminders
             user.email_user(
                 subject=subject,
                 message=rendered_message,
-                from_email=user_office_email,
+                from_email=from_email,
+                cc=cc,
                 email_category=EmailCategory.TIMED_SERVICES,
                 email_notification=email_notification,
             )
@@ -616,13 +653,20 @@ def send_email_usage_reminders(projects_to_exclude=None, request=None):
     if message:
         busy_staff = StaffCharge.objects.filter(end=None)
         for staff_charge in busy_staff:
-            subject = "Active staff charge since " + format_datetime(staff_charge.start)
-            rendered_message = render_email_template(message, {"staff_charge": staff_charge}, request)
+            dictionary = {
+                "staff_charge": staff_charge,
+                "default_subject": "Active staff charge since " + format_datetime(staff_charge.start),
+                "default_from_email": user_office_email,
+                "default_cc_emails": "",
+            }
+            rendered_message = render_email_template(message, dictionary, request)
+            subject, from_email, cc = resolve_email_customization("staff_charge_reminder_email", dictionary)
             email_notification = staff_charge.staff_member.get_preferences().email_send_usage_reminders
             staff_charge.staff_member.email_user(
                 subject=subject,
                 message=rendered_message,
-                from_email=user_office_email,
+                from_email=from_email,
+                cc=cc,
                 email_category=EmailCategory.TIMED_SERVICES,
                 email_notification=email_notification,
             )
@@ -661,6 +705,7 @@ def send_email_reservation_reminders(request=None):
     for reservation in upcoming_reservations:
         item = reservation.reservation_item
         item_type = reservation.reservation_item_type
+        user_office_email = EmailsCustomization.get("user_office_email_address")
         if (
             item_type == ReservationItemType.TOOL
             and item.operational
@@ -669,38 +714,46 @@ def send_email_reservation_reminders(request=None):
             or item_type == ReservationItemType.AREA
             and not item.required_resource_is_unavailable()
         ):
-            subject = item.name + " reservation reminder"
-            rendered_message = render_email_template(
-                reservation_reminder_message,
-                {"reservation": reservation, "template_color": bootstrap_primary_color("success")},
-                request,
-            )
+            template_name = "reservation_reminder_email"
+            dictionary = {
+                "reservation": reservation,
+                "template_color": bootstrap_primary_color("success"),
+                "default_subject": item.name + " reservation reminder",
+                "default_from_email": user_office_email,
+                "default_cc_emails": "",
+            }
+            rendered_message = render_email_template(reservation_reminder_message, dictionary, request)
         elif (
             item_type == ReservationItemType.TOOL and not item.operational
         ) or item.required_resource_is_unavailable():
-            subject = item.name + " reservation problem"
-            rendered_message = render_email_template(
-                reservation_warning_message,
-                {"reservation": reservation, "template_color": bootstrap_primary_color("danger"), "fatal_error": True},
-                request,
-            )
+            template_name = "reservation_warning_email"
+            dictionary = {
+                "reservation": reservation,
+                "template_color": bootstrap_primary_color("danger"),
+                "fatal_error": True,
+                "default_subject": item.name + " reservation problem",
+                "default_from_email": user_office_email,
+                "default_cc_emails": "",
+            }
+            rendered_message = render_email_template(reservation_warning_message, dictionary, request)
         else:
-            subject = item.name + " reservation warning"
-            rendered_message = render_email_template(
-                reservation_warning_message,
-                {
-                    "reservation": reservation,
-                    "template_color": bootstrap_primary_color("warning"),
-                    "fatal_error": False,
-                },
-                request,
-            )
-        user_office_email = EmailsCustomization.get("user_office_email_address")
+            template_name = "reservation_warning_email"
+            dictionary = {
+                "reservation": reservation,
+                "template_color": bootstrap_primary_color("warning"),
+                "fatal_error": False,
+                "default_subject": item.name + " reservation warning",
+                "default_from_email": user_office_email,
+                "default_cc_emails": "",
+            }
+            rendered_message = render_email_template(reservation_warning_message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization(template_name, dictionary)
         email_notification = reservation.user.get_preferences().email_send_reservation_reminders
         reservation.user.email_user(
             subject=subject,
             message=rendered_message,
-            from_email=user_office_email,
+            from_email=from_email,
+            cc=cc,
             email_category=EmailCategory.TIMED_SERVICES,
             email_notification=email_notification,
         )
@@ -781,14 +834,23 @@ def send_weekend_email_access(access, user_office_email, email_to, contents, beg
     sat = format_datetime(beginning_of_the_week + timedelta(days=5), "SHORT_DATE_FORMAT", as_current_timezone=False)
     sun = format_datetime(beginning_of_the_week + timedelta(days=6), "SHORT_DATE_FORMAT", as_current_timezone=False)
 
-    subject = f"{'NO w' if not access else 'W'}eekend access for the {facility_name} {sat} - {sun}"
-    message = render_email_template(contents, {"weekend_access": access})
+    dictionary = {
+        "weekend_access": access,
+        "facility_name": facility_name,
+        "sat": sat,
+        "sun": sun,
+        "default_subject": f"{'NO w' if not access else 'W'}eekend access for the {facility_name} {sat} - {sun}",
+        "default_from_email": user_office_email,
+        "default_cc_emails": ", ".join(ccs),
+    }
+    message = render_email_template(contents, dictionary)
+    subject, from_email, cc = resolve_email_customization("weekend_access_email", dictionary)
     send_mail(
         subject=subject,
         content=message,
-        from_email=user_office_email,
+        from_email=from_email,
         to=recipients,
-        cc=ccs,
+        cc=cc,
         email_category=EmailCategory.ACCESS_REQUESTS,
     )
 
@@ -811,14 +873,24 @@ def send_email_user_access_expiration_reminders(request=None):
         for remaining_days in [int(days) for days in access_expiration_reminder_days.split(",")]:
             expiration_date = date.today() + timedelta(days=remaining_days)
             for user in User.objects.filter(is_active=True, access_expiration=expiration_date):
-                subject = f"Your {facility_name} access expires in {remaining_days} days ({format_datetime(user.access_expiration)})"
-                message = render_email_template(template, {"user": user, "remaining_days": remaining_days}, request)
+                dictionary = {
+                    "user": user,
+                    "remaining_days": remaining_days,
+                    "facility_name": facility_name,
+                    "default_subject": f"Your {facility_name} access expires in {remaining_days} days ({format_datetime(user.access_expiration)})",
+                    "default_from_email": user_office_email,
+                    "default_cc_emails": ", ".join(ccs),
+                }
+                message = render_email_template(template, dictionary, request)
+                subject, from_email, cc = resolve_email_customization(
+                    "user_access_expiration_reminder_email", dictionary
+                )
                 email_notification = user.get_preferences().email_send_access_expiration_emails
                 user.email_user(
                     subject=subject,
                     message=message,
-                    from_email=user_office_email,
-                    cc=ccs,
+                    from_email=from_email,
+                    cc=cc,
                     email_notification=email_notification,
                     email_category=EmailCategory.ACCESS_EXPIRATION_REMINDERS,
                 )
@@ -901,7 +973,6 @@ def send_tool_qualification_expiring_email(
         subject_expiration = f" expires in {remaining_days} days!"
     else:
         subject_expiration = " has expired"
-    subject = f"Your {qualification.tool.name} qualification {subject_expiration}"
     dictionary = {
         "user": qualification.user,
         "tool": qualification.tool,
@@ -909,14 +980,18 @@ def send_tool_qualification_expiring_email(
         "expiration_date": expiration_date,
         "qualification_date": qualification.qualified_on,
         "remaining_days": remaining_days,
+        "default_subject": f"Your {qualification.tool.name} qualification {subject_expiration}",
+        "default_from_email": user_office_email,
+        "default_cc_emails": ", ".join(cc_email or []),
     }
     message = render_email_template(template, dictionary, request)
+    subject, from_email, cc = resolve_email_customization("tool_qualification_expiration_email", dictionary)
     email_notification = qualification.user.get_preferences().email_send_tool_qualification_expiration_emails
     qualification.user.email_user(
         subject=subject,
         message=message,
-        from_email=user_office_email,
-        cc=cc_email,
+        from_email=from_email,
+        cc=cc,
         email_notification=email_notification,
     )
 
@@ -978,14 +1053,21 @@ def send_recurring_charge_reminders(request, reminders: Iterable[Dict]):
     recurring_charges_name = RecurringChargesCustomization.get("recurring_charges_name")
     if message and user_office_email:
         for user_reminders in reminders:
-            subject = f"{recurring_charges_name} will be charged in {user_reminders['reminder_days']} day(s)"
+            user_reminders["recurring_charges_name"] = recurring_charges_name
+            user_reminders["default_subject"] = (
+                f"{recurring_charges_name} will be charged in {user_reminders['reminder_days']} day(s)"
+            )
+            user_reminders["default_from_email"] = user_office_email
+            user_reminders["default_cc_emails"] = ""
             user_instance: User = user_reminders["user"]
             rendered_message = render_email_template(message, user_reminders, request)
+            subject, from_email, cc = resolve_email_customization("recurring_charges_reminder_email", user_reminders)
             email_notification = user_instance.get_preferences().email_send_recurring_charges_reminder_emails
             user_instance.email_user(
                 subject=subject,
                 message=rendered_message,
-                from_email=user_office_email,
+                from_email=from_email,
+                cc=cc,
                 email_category=EmailCategory.TIMED_SERVICES,
                 email_notification=email_notification,
             )
@@ -1042,13 +1124,20 @@ def send_email_scheduled_outage_reminders(request=None) -> HttpResponse:
                 if is_date_in_datetime_range(outage_date, start, end):
                     outages_to_send_reminders_for.add(future_outage)
     for outage in outages_to_send_reminders_for:
-        subject = f"{outage.title} reminder"
-        rendered_message = render_email_template(message, {"outage": outage}, request)
+        dictionary = {
+            "outage": outage,
+            "default_subject": f"{outage.title} reminder",
+            "default_from_email": get_email_from_settings(),
+            "default_cc_emails": "",
+        }
+        rendered_message = render_email_template(message, dictionary, request)
+        subject, from_email, cc = resolve_email_customization("scheduled_outage_reminder_email", dictionary)
         send_mail(
             subject=subject,
             content=rendered_message,
-            from_email=get_email_from_settings(),
+            from_email=from_email,
             to=outage.reminder_emails,
+            cc=cc,
             email_category=EmailCategory.TIMED_SERVICES,
         )
     return HttpResponse()

--- a/NEMO/views/tool_control.py
+++ b/NEMO/views/tool_control.py
@@ -60,6 +60,7 @@ from NEMO.views.customization import (
     ToolControlCustomization,
     ToolCustomization,
     get_media_file_contents,
+    resolve_email_customization,
 )
 from NEMO.widgets.configuration_editor import ConfigurationEditor
 from NEMO.widgets.dynamic_form import PostUsageQuestion
@@ -843,16 +844,24 @@ def email_managers_required_questions_disable_tool(
         )
         ccs = [email for user in cc_users for email in user.get_emails(EmailNotificationType.BOTH_EMAILS)]
         ccs.append(abuse_email_address)
-        rendered_message = render_email_template(
-            message, {"user": tool_user, "tool": tool, "questions": questions, "usage_event": usage_event}
-        )
+        dictionary = {
+            "user": tool_user,
+            "tool": tool,
+            "questions": questions,
+            "usage_event": usage_event,
+            "default_subject": f"Unanswered post‑usage questions after logoff from the {tool.name}",
+            "default_from_email": user_office_email,
+            "default_cc_emails": ", ".join(ccs),
+        }
+        rendered_message = render_email_template(message, dictionary)
+        subject, from_email, cc = resolve_email_customization("tool_required_unanswered_questions_email", dictionary)
         tos = tool_user.get_emails(EmailNotificationType.BOTH_EMAILS)
         send_mail(
-            subject=f"Unanswered post‑usage questions after logoff from the {tool.name}",
+            subject=subject,
             content=rendered_message,
-            from_email=user_office_email,
+            from_email=from_email,
             to=tos,
-            cc=ccs,
+            cc=cc,
             email_category=EmailCategory.ABUSE,
         )
 
@@ -861,13 +870,20 @@ def send_tool_usage_counter_email(counter: ToolUsageCounter):
     user_office_email = EmailsCustomization.get("user_office_email_address")
     message = get_media_file_contents("counter_threshold_reached_email.html")
     if user_office_email and message:
-        subject = f"Warning threshold reached for {counter.tool.name} {counter.name} counter"
-        rendered_message = render_email_template(message, {"counter": counter})
+        dictionary = {
+            "counter": counter,
+            "default_subject": f"Warning threshold reached for {counter.tool.name} {counter.name} counter",
+            "default_from_email": user_office_email,
+            "default_cc_emails": "",
+        }
+        rendered_message = render_email_template(message, dictionary)
+        subject, from_email, cc = resolve_email_customization("counter_threshold_reached_email", dictionary)
         send_mail(
             subject=subject,
             content=rendered_message,
-            from_email=user_office_email,
+            from_email=from_email,
             to=counter.warning_email,
+            cc=cc,
             email_category=EmailCategory.SYSTEM,
         )
 

--- a/NEMO/views/tutorials.py
+++ b/NEMO/views/tutorials.py
@@ -4,7 +4,12 @@ from django.views.decorators.http import require_http_methods
 
 from NEMO.models import Project, User
 from NEMO.utilities import EmailCategory, render_email_template, send_mail
-from NEMO.views.customization import ApplicationCustomization, EmailsCustomization, get_media_file_contents
+from NEMO.views.customization import (
+    ApplicationCustomization,
+    EmailsCustomization,
+    get_media_file_contents,
+    resolve_email_customization,
+)
 
 
 @login_required
@@ -22,16 +27,25 @@ def facility_rules(request):
     elif request.method == "POST":
         facility_name = ApplicationCustomization.get("facility_name")
         summary = request.POST.get("making_reservations_summary", "").strip()[:3000]
-        dictionary = {"user": request.user, "making_reservations_rule_summary": summary}
+        dictionary = {
+            "user": request.user,
+            "making_reservations_rule_summary": summary,
+            "facility_name": facility_name,
+            "default_subject": f"{facility_name} rules tutorial",
+            "default_from_email": EmailsCustomization.get("abuse_email_address"),
+            "default_cc_emails": "",
+        }
         abuse_email = EmailsCustomization.get("abuse_email_address")
         email_contents = get_media_file_contents("facility_rules_tutorial_email.html")
         if abuse_email and email_contents:
             message = render_email_template(email_contents, dictionary, request)
+            subject, from_email, cc = resolve_email_customization("facility_rules_tutorial_email", dictionary)
             send_mail(
-                subject=f"{facility_name} rules tutorial",
+                subject=subject,
                 content=message,
-                from_email=abuse_email,
+                from_email=from_email,
                 to=[abuse_email],
+                cc=cc,
                 email_category=EmailCategory.SYSTEM,
             )
         dictionary = {


### PR DESCRIPTION
This is a pretty large pull request that resolves #290 by implementing it as closely as possible (with some caveats) by introducing the ability to edit each emails subject/from/cc fields, add your own from the NEMO customization page, and also edit the code for the HTML files from the NEMO page.  

- TemplatesCustomization now registers a `_subject`, `_from` and `_cc` variable for every entry as described. Each are rendered as Django templates and can reference from the user  
- All fields can reference variables like `{{ customizations|get_item:"user_office_email_address" }}` directly, covering the "variable resolution" idea
- All of this lives on the File & email templates page, with a per-email "save this email's settings" button and inline confirmation, plus an editable textarea for the file content itself
  - Also implemented the preset options as a datalist html widget 
- Email entries now use a .email marker extension instead of .html, translated back to .html only where the file is actually read/written, so in existing templats had to change
- Added the data migration for backporting the subject text (with the original conditional logic, not just a static string) for 27 of 28 templates. Skipped the broadcast email, which has no fixed subject
- Added a new `resolve_email_customization(template_name, dictionary, request=None)` method to `NEMO/views/customization.py` that is now used all across email operations before sending mail, rendering that template's _subject/_from/_cc values as Django templates against the same context dict as the email body, splits/strips cc into a list, finally returning (subject, from_email, cc) for send_mail
- Wrote extra tests for the customization and email cc'ing
  - cc sent as its own send_mail() call rather than attached to the bcc chunking

Screenshots in the "Files & email templates" page:

<img width="1126" height="588" alt="Screenshot From 2026-09-07 19-28-18" src="https://github.com/user-attachments/assets/a5d40a0c-04ae-4840-9277-0e827834f2cb" />

<img width="1110" height="869" alt="Screenshot From 2026-09-07 19-28-33" src="https://github.com/user-attachments/assets/c1557444-0247-4e0a-8623-79f28183a802" />

Video demonstration of editing the files/settings and using the dropdown:

https://github.com/user-attachments/assets/f4800577-2c65-45fc-95b3-98863283c9fe

NOTE: This PR depends upon https://github.com/usnistgov/NEMO/pull/334, since it builds upon that migration.